### PR TITLE
Add language dropdown for import

### DIFF
--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/ImportDeckView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/ImportDeckView.xaml
@@ -21,6 +21,19 @@
         <TextBox Grid.Column="1" Height="20" Margin="10,0" Background="Transparent" Foreground="White" Text="{Binding DeckFilePath}" FontFamily="{StaticResource CoreFont}" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
         <Button Grid.Column="2" Margin="5" Height="25" Style="{DynamicResource FlatButtonStyle}" Command="{Binding BrowseFileCommand}" Background="{StaticResource Good}">Browse</Button>
 
-        <Button Grid.Column="1" Grid.Row="1" Height="30" Margin="20,0" Style="{DynamicResource FlatButtonStyle}" Background="{StaticResource Good}" Command="{Binding ImportSelectedPathCommand}">Import</Button>
+        <ComboBox Grid.Column="1" Grid.Row="1" Width="120" Margin="0,0,100,0" HorizontalAlignment="Left" Foreground="Black" Background="{StaticResource MainLight}" SelectedValuePath="Content" SelectedValue="{Binding SelectedLanguage, FallbackValue=French}">
+            <ComboBoxItem>French</ComboBoxItem>
+            <ComboBoxItem>English</ComboBoxItem>
+            <ComboBoxItem>Japanese</ComboBoxItem>
+            <ComboBoxItem>Spanish</ComboBoxItem>
+            <ComboBoxItem>Portuguese</ComboBoxItem>
+            <ComboBoxItem>Korean</ComboBoxItem>
+            <ComboBoxItem>German</ComboBoxItem>
+            <ComboBoxItem>Italian</ComboBoxItem>
+            <ComboBoxItem>Russian</ComboBoxItem>
+            <ComboBoxItem>Simplified Chinese</ComboBoxItem>
+            <ComboBoxItem>Traditional Chinese</ComboBoxItem>
+        </ComboBox>
+        <Button Grid.Column="1" Grid.Row="1" Height="30" Margin="150,0,0,0" HorizontalAlignment="Left" Style="{DynamicResource FlatButtonStyle}" Background="{StaticResource Good}" Command="{Binding ImportSelectedPathCommand}">Import</Button>
     </Grid>
 </UserControl>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/MergeDeckView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/MergeDeckView.xaml
@@ -26,6 +26,19 @@
         <TextBox Grid.Row="1" Grid.Column="1" Height="20" Margin="10,0" Background="Transparent" Foreground="White" Text="{Binding NewDeckFilePath}" FontFamily="{StaticResource CoreFont}" VerticalAlignment="Center" VerticalContentAlignment="Center"/>
         <Button Grid.Row="1" Grid.Column="2" Margin="5" Height="25" Style="{DynamicResource FlatButtonStyle}" Command="{Binding NewBrowseFileCommand}" Background="{StaticResource Good}">Browse</Button>
         
-        <Button Grid.Column="1" Grid.Row="2" Height="30" Margin="20,0" Style="{DynamicResource FlatButtonStyle}" Background="{StaticResource Good}" Command="{Binding ImportSelectedPathCommand}">Import</Button>
+        <ComboBox Grid.Column="1" Grid.Row="2" Width="120" Margin="0,0,100,0" HorizontalAlignment="Left" Foreground="Black" Background="{StaticResource MainLight}" SelectedValuePath="Content" SelectedValue="{Binding SelectedLanguage, FallbackValue=French}">
+            <ComboBoxItem>French</ComboBoxItem>
+            <ComboBoxItem>English</ComboBoxItem>
+            <ComboBoxItem>Japanese</ComboBoxItem>
+            <ComboBoxItem>Spanish</ComboBoxItem>
+            <ComboBoxItem>Portuguese</ComboBoxItem>
+            <ComboBoxItem>Korean</ComboBoxItem>
+            <ComboBoxItem>German</ComboBoxItem>
+            <ComboBoxItem>Italian</ComboBoxItem>
+            <ComboBoxItem>Russian</ComboBoxItem>
+            <ComboBoxItem>Simplified Chinese</ComboBoxItem>
+            <ComboBoxItem>Traditional Chinese</ComboBoxItem>
+        </ComboBox>
+        <Button Grid.Column="1" Grid.Row="2" Height="30" Margin="150,0,0,0" HorizontalAlignment="Left" Style="{DynamicResource FlatButtonStyle}" Background="{StaticResource Good}" Command="{Binding ImportSelectedPathCommand}">Import</Button>
     </Grid>
 </UserControl>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/DeckBuilderViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/DeckBuilderViewModel.cs
@@ -42,6 +42,8 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
         private string _cardBackURL { get; set; }
 
+        public string PreferredLanguage { get; set; } = "fr";
+
         public string CardBackURL
         {
             get
@@ -243,7 +245,12 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
         private string FetchPreferredImage(string cardName, bool isBack)
         {
-            string[] languages = new[] { "fr", "en" };
+            List<string> languages = new List<string>();
+            if (!string.IsNullOrWhiteSpace(PreferredLanguage))
+            {
+                languages.Add(PreferredLanguage);
+            }
+            if (PreferredLanguage != "en") languages.Add("en");
 
             foreach (string lang in languages)
             {

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/ImportDeckViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/ImportDeckViewModel.cs
@@ -33,6 +33,39 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
         private DeckBuilderViewModel _deckBuilderViewModel { get; set; }
 
+        private Dictionary<string, string> LanguageConverter = new Dictionary<string, string>
+        {
+            {"French", "fr"},
+            {"English", "en"},
+            {"Japanese", "ja"},
+            {"Spanish", "es"},
+            {"Portuguese", "pt"},
+            {"Korean", "ko"},
+            {"German", "de"},
+            {"Italian", "it"},
+            {"Russian", "ru"},
+            {"Simplified Chinese", "zhs"},
+            {"Traditional Chinese", "zht"}
+        };
+
+        public IEnumerable<string> Languages
+        {
+            get { return LanguageConverter.Keys; }
+        }
+
+        private string _selectedLanguage;
+        public string SelectedLanguage
+        {
+            get
+            {
+                return string.IsNullOrEmpty(_selectedLanguage) ? "French" : _selectedLanguage;
+            }
+            set
+            {
+                _selectedLanguage = value;
+            }
+        }
+
         public ICommand BrowseFileCommand { get; } //Command to Open File Browser and Populate DeckFilePath textbox on selection
         public ICommand ImportSelectedPathCommand { get; } //Command to execute the import operation. Hands off the new DeckInfoStore to the DeckBuilderVM to begin the import process.
         public ICommand NavigateToDeckViewCommand { get; set; } //Standard Navigation Command to move to the Deck Builder
@@ -79,6 +112,14 @@ namespace TTSDeckEditAndCreationTool.ViewModel
         public void ConvertPathToDeckAndNavigate()
         {
             deckInfo.DeckPath = DeckFilePath;
+            if(LanguageConverter.ContainsKey(SelectedLanguage))
+            {
+                _deckBuilderViewModel.PreferredLanguage = LanguageConverter[SelectedLanguage];
+            }
+            else
+            {
+                _deckBuilderViewModel.PreferredLanguage = "fr";
+            }
 
             NavigateToDeckViewCommand.Execute(null);
 

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/MergeDeckViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/MergeDeckViewModel.cs
@@ -41,6 +41,33 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
         private DeckBuilderViewModel _deckBuilderViewModel { get; set; }
 
+        private Dictionary<string, string> LanguageConverter = new Dictionary<string, string>
+        {
+            {"French", "fr"},
+            {"English", "en"},
+            {"Japanese", "ja"},
+            {"Spanish", "es"},
+            {"Portuguese", "pt"},
+            {"Korean", "ko"},
+            {"German", "de"},
+            {"Italian", "it"},
+            {"Russian", "ru"},
+            {"Simplified Chinese", "zhs"},
+            {"Traditional Chinese", "zht"}
+        };
+
+        public IEnumerable<string> Languages
+        {
+            get { return LanguageConverter.Keys; }
+        }
+
+        private string _selectedLanguage;
+        public string SelectedLanguage
+        {
+            get { return string.IsNullOrEmpty(_selectedLanguage) ? "French" : _selectedLanguage; }
+            set { _selectedLanguage = value; }
+        }
+
         public ICommand NewBrowseFileCommand { get; }
         public ICommand OldBrowseFileCommand { get; }
         public ICommand ImportSelectedPathCommand { get; }
@@ -89,6 +116,15 @@ namespace TTSDeckEditAndCreationTool.ViewModel
         public void ConvertPathToDeckAndNavigate()
         {
             deckInfo.DeckPath = NewDeckFilePath;
+
+            if (LanguageConverter.ContainsKey(SelectedLanguage))
+            {
+                _deckBuilderViewModel.PreferredLanguage = LanguageConverter[SelectedLanguage];
+            }
+            else
+            {
+                _deckBuilderViewModel.PreferredLanguage = "fr";
+            }
 
             NavigateToDeckViewCommand.Execute(null);
 


### PR DESCRIPTION
## Summary
- allow selecting the preferred language when importing
- support same language choice when merging
- fetch card art with the selected language first

## Testing
- `dotnet build TTSDeckEditAndCreationTool.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889371efe04832287b9cc1a8c02c47c