### PR TITLE
Add deckbuilder import summary

### DIFF
--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DeckBuilderView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DeckBuilderView.xaml
@@ -37,5 +37,6 @@
         </ScrollViewer>
 
         <Rectangle Grid.Row="2" Fill="{StaticResource MainLight}"/>
+        <Label Grid.Row="2" Foreground="White" VerticalAlignment="Center" FontFamily="{StaticResource LightFont}" Margin="5" Content="{Binding ImportSummary}"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- track successful and fallback card fetch counts
- display a live summary of fetched cards in the Deck Builder

## Testing
- `dotnet build TTSDeckEditAndCreationTool.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889bb8faa908322ae74b1cf6c817ea2