### PR TITLE
Async deck import for progress updates

### DIFF
--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/ImportDeckViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/ImportDeckViewModel.cs
@@ -109,7 +109,7 @@ namespace TTSDeckEditAndCreationTool.ViewModel
         /// Set DeckInfoStores info, Navigate to DeckBuilder, and Call Deck Builders LoadFromPath to import the deckpath.
         /// This is called from the ImportSelectedPathCommand. See: Commands/ImportAndConvertCommand.cs
         /// </summary>
-        public void ConvertPathToDeckAndNavigate()
+        public async Task ConvertPathToDeckAndNavigate()
         {
             deckInfo.DeckPath = DeckFilePath;
             if(LanguageConverter.ContainsKey(SelectedLanguage))
@@ -123,7 +123,10 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
             NavigateToDeckViewCommand.Execute(null);
 
-            _deckBuilderViewModel?.LoadFromPath(DeckFilePath);
+            if (_deckBuilderViewModel != null)
+            {
+                await _deckBuilderViewModel.LoadFromPath(DeckFilePath);
+            }
         }
     }
 }

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/MergeDeckViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/MergeDeckViewModel.cs
@@ -113,7 +113,7 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             }
         }
 
-        public void ConvertPathToDeckAndNavigate()
+        public async Task ConvertPathToDeckAndNavigate()
         {
             deckInfo.DeckPath = NewDeckFilePath;
 
@@ -128,7 +128,10 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
             NavigateToDeckViewCommand.Execute(null);
 
-            _deckBuilderViewModel?.MergeFromPaths(NewDeckFilePath, OldDeckFilePath);
+            if (_deckBuilderViewModel != null)
+            {
+                await _deckBuilderViewModel.MergeFromPaths(NewDeckFilePath, OldDeckFilePath);
+            }
         }
     }
 }

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/ViewModelBase.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/ViewModelBase.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace TTSDeckEditAndCreationTool.ViewModel
 {
@@ -13,7 +14,17 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
         protected void OnPropertyChanged(string propertyName = null)
         {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            if (Application.Current != null && !Application.Current.Dispatcher.CheckAccess())
+            {
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+                });
+            }
+            else
+            {
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+            }
         }
 
         public virtual void Dispose() { }


### PR DESCRIPTION
## Summary
- dispatch property change updates on UI thread
- make deck loading methods asynchronous
- call async deck import from ImportDeck and MergeDeck view models

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d265e3048322aa9faeaaa472dc59