### PR TITLE
Feature/typed models and series picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,11 @@ obj/
 
 # VS config
 .vs/
+
+# Skills installés localement (mattpocock/skills via npx skills)
+TTSDeckEditAndCreationTool/.agents/
+TTSDeckEditAndCreationTool/.claude/skills/
+
+# Fichiers de test locaux (decks TTS, convertisseur de référence) — ne pas committer
+TTSDeckEditAndCreationTool/sample/
+TTSDeckEditAndCreationTool/reference/

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Commands/GenerateDeckFromListCommand.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Commands/GenerateDeckFromListCommand.cs
@@ -1,0 +1,20 @@
+using TTSDeckEditAndCreationTool.ViewModel;
+
+namespace TTSDeckEditAndCreationTool.Commands
+{
+    /// <summary>Parses the pasted decklist and navigates to the gallery to resolve/generate it.</summary>
+    public class GenerateDeckFromListCommand : CommandBase
+    {
+        private readonly DecklistImportViewModel _viewModel;
+
+        public GenerateDeckFromListCommand(DecklistImportViewModel viewModel)
+        {
+            _viewModel = viewModel;
+        }
+
+        public override async void Execute(object parameter)
+        {
+            await _viewModel.GenerateDeckAndNavigate();
+        }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Commands/RefetchLanguageCommand.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Commands/RefetchLanguageCommand.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using TTSDeckEditAndCreationTool.ViewModel;
+
+namespace TTSDeckEditAndCreationTool.Commands
+{
+    /// <summary>
+    /// Forces a re-download of every card's art in the deck's PreferredLanguage,
+    /// even for decks already marked processed (isUpdated). Bound to the gallery's
+    /// "Re-DL" button. See DeckBuilderViewModel.RefreshImagesInPreferredLanguage.
+    /// </summary>
+    class RefetchLanguageCommand : CommandBase
+    {
+        private readonly DeckBuilderViewModel _deckBuilderViewModel;
+
+        public RefetchLanguageCommand(DeckBuilderViewModel deckBuilderViewModel)
+        {
+            _deckBuilderViewModel = deckBuilderViewModel;
+        }
+
+        public override async void Execute(object parameter)
+        {
+            if (_deckBuilderViewModel != null)
+            {
+                await _deckBuilderViewModel.RefreshImagesInPreferredLanguage();
+            }
+        }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/MainWindow.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/MainWindow.xaml
@@ -41,6 +41,9 @@
                 <DataTemplate DataType="{x:Type viewmodels:ImportDeckViewModel}">
                     <views:ImportDeckView/>
                 </DataTemplate>
+                <DataTemplate DataType="{x:Type viewmodels:DecklistImportViewModel}">
+                    <views:DecklistImportView/>
+                </DataTemplate>
                 <DataTemplate DataType="{x:Type viewmodels:DeckBuilderViewModel}">
                     <views:DeckBuilderView/>
                 </DataTemplate>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/DeckCard.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/DeckCard.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Input;
+﻿using System.Collections.Generic;
 
 namespace TTSDeckEditAndCreationTool.Model
 {
@@ -18,6 +13,15 @@ namespace TTSDeckEditAndCreationTool.Model
 
         public string FaceURL { get; set; }
         public string OldFaceURL { get; set; }
+
+        // --- Generation mode (decklist -> JSON) extras ---
+        // Optional precise print requested from the decklist line "Name (SET) NUMBER".
+        public string SetCode { get; set; }
+        public string CollectorNumber { get; set; }
+        // Back-face image for double-faced/modal cards. When set, the generator emits
+        // this card as a single object carrying its verso in States["2"] (see TtsDeckBuilder).
+        // null for ordinary single-faced cards (their physical back is the deck BackURL).
+        public string BackFaceURL { get; set; }
 
         List<string> PrintURLs { get; set; }
 

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/DecklistParser.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/DecklistParser.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace TTSDeckEditAndCreationTool.Model
+{
+    /// <summary>A single line of a decklist, resolved to a quantity, a card name
+    /// and (optionally) the precise print requested via "(SET) NUMBER".</summary>
+    public class ParsedDeckLine
+    {
+        public int Count { get; set; }
+        public string Name { get; set; }
+        public string SetCode { get; set; }          // null when no set was given
+        public string CollectorNumber { get; set; }  // null when no collector number was given
+    }
+
+    /// <summary>
+    /// Parses a pasted Magic decklist (Moxfield / Archidekt / MTGA / EDHRec text export)
+    /// into <see cref="ParsedDeckLine"/>s.
+    ///
+    /// Accepted shapes per line (quantity optional, set/number optional):
+    ///   "2 Lightning Bolt (2X2) 117"
+    ///   "1x Sol Ring (C21) 263"
+    ///   "1 Sol Ring"
+    ///   "Sol Ring"                (assumed quantity 1)
+    /// Foil/flag markers (e.g. "*F*") and bracket tags (e.g. "[Ramp]") are stripped.
+    /// Blank lines, comments (// or #) and section headers ("Commander", "Deck:",
+    /// "Sideboard (15)") are ignored. The set/number suffix is only recognised at the
+    /// very end of the line, so card names that themselves contain parentheses survive.
+    /// </summary>
+    public static class DecklistParser
+    {
+        // Leading "12 " / "12x " / "12X " quantity.
+        private static readonly Regex QuantityRegex =
+            new Regex(@"^\s*(\d+)\s*[xX]?\s+(.+)$", RegexOptions.Compiled);
+
+        // Trailing "(SET) 123" / "(SET) 123a" / "(SET)" suffix. Set code is 2-6 alphanumerics.
+        private static readonly Regex SetSuffixRegex =
+            new Regex(@"^(.*?)\s*\(([A-Za-z0-9]{2,6})\)(?:\s+([A-Za-z0-9\-★]+))?\s*$", RegexOptions.Compiled);
+
+        private static readonly HashSet<string> KnownHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "deck", "commander", "commanders", "sideboard", "maybeboard",
+            "companion", "tokens", "planes", "schemes", "about"
+        };
+
+        public static List<ParsedDeckLine> Parse(string text)
+        {
+            var result = new List<ParsedDeckLine>();
+            if (string.IsNullOrWhiteSpace(text)) return result;
+
+            foreach (string rawLine in text.Replace("\r\n", "\n").Split('\n'))
+            {
+                ParsedDeckLine line = ParseLine(rawLine);
+                if (line != null) result.Add(line);
+            }
+            return result;
+        }
+
+        private static ParsedDeckLine ParseLine(string rawLine)
+        {
+            string line = rawLine?.Trim();
+            if (string.IsNullOrEmpty(line)) return null;
+            if (line.StartsWith("//") || line.StartsWith("#")) return null;
+
+            // Strip trailing foil/flag markers ("*F*") and bracket tags ("[Ramp]").
+            line = Regex.Replace(line, @"\s*\*[^*]*\*\s*$", "").Trim();
+            line = Regex.Replace(line, @"\s*\[[^\]]*\]\s*$", "").Trim();
+            if (line.Length == 0) return null;
+
+            int count = 1;
+            string rest = line;
+
+            Match qty = QuantityRegex.Match(line);
+            if (qty.Success)
+            {
+                count = int.Parse(qty.Groups[1].Value);
+                rest = qty.Groups[2].Value.Trim();
+            }
+            else
+            {
+                // No leading quantity: could be "Sol Ring" (a card) or a section header.
+                // Strip a trailing "(n)" count and ":" then match against known headers,
+                // so "Sideboard (15)", "Commander", "Deck:" are all recognised and skipped
+                // — while a real card like "Sol Ring" (not a known header) falls through.
+                string headerProbe = Regex.Replace(line, @"\s*\(\d+\)\s*$", "").TrimEnd(':').Trim();
+                if (KnownHeaders.Contains(headerProbe)) return null;
+            }
+
+            if (count <= 0) return null;
+
+            string name = rest;
+            string setCode = null;
+            string collector = null;
+
+            Match suffix = SetSuffixRegex.Match(rest);
+            if (suffix.Success && suffix.Groups[1].Value.Trim().Length > 0)
+            {
+                name = suffix.Groups[1].Value.Trim();
+                setCode = suffix.Groups[2].Value.Trim();
+                collector = suffix.Groups[3].Success ? suffix.Groups[3].Value.Trim() : null;
+                if (collector != null && collector.Length == 0) collector = null;
+            }
+
+            if (string.IsNullOrWhiteSpace(name)) return null;
+
+            return new ParsedDeckLine
+            {
+                Count = count,
+                Name = name,
+                SetCode = setCode,
+                CollectorNumber = collector
+            };
+        }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/MagicSet.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/MagicSet.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace TTSDeckEditAndCreationTool.Model
+{
+    /// <summary>
+    /// A Magic set/series as returned by Scryfall's /sets endpoint.
+    /// Only the fields we need to populate the series picker are modelled.
+    /// </summary>
+    public class MagicSet
+    {
+        [JsonPropertyName("code")]
+        public string Code { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("released_at")]
+        public string ReleasedAt { get; set; }
+
+        [JsonPropertyName("set_type")]
+        public string SetType { get; set; }
+
+        /// <summary>Text shown in the dropdown, e.g. "Final Fantasy (FIN)".</summary>
+        [JsonIgnore]
+        public string Display => $"{Name} ({Code?.ToUpper()})";
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/TTSModels.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/TTSModels.cs
@@ -1,1 +1,83 @@
-﻿
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TTSDeckEditAndCreationTool.Model
+{
+    /// <summary>
+    /// Typed, round-trip-safe representation of a Tabletop Simulator save file
+    /// (the JSON the app imports/exports).
+    ///
+    /// Only the fields the app actually reads are modelled. Every other field
+    /// TTS writes (Transform, ColorDiffuse, LuaScript, GUID, Tags, ...) is
+    /// captured verbatim through <see cref="JsonExtensionData"/> so it survives
+    /// a deserialize/serialize round trip without loss. This lets us navigate
+    /// the save with strong typing instead of brute-force JsonElement probing,
+    /// while keeping unknown data intact.
+    ///
+    /// Note: TTS uses PascalCase property names, but this app's own marker
+    /// (<c>isUpdated</c>) is camelCase, so every property declares its JSON
+    /// name explicitly rather than relying on a global naming policy.
+    /// </summary>
+    public class TtsSaveFile
+    {
+        [JsonPropertyName("ObjectStates")]
+        public List<TtsObject> ObjectStates { get; set; }
+
+        /// <summary>App-specific marker: set once a deck has been processed/saved.</summary>
+        [JsonPropertyName("isUpdated")]
+        public bool? IsUpdated { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; set; }
+    }
+
+    /// <summary>
+    /// A TTS object inside ObjectStates (or nested in a deck pile). The same
+    /// shape covers a single card and a deck pile of cards — a pile is simply
+    /// an object that carries <see cref="ContainedObjects"/>.
+    /// </summary>
+    public class TtsObject
+    {
+        [JsonPropertyName("Nickname")]
+        public string Nickname { get; set; }
+
+        [JsonPropertyName("CardID")]
+        public int? CardID { get; set; }
+
+        /// <summary>Custom image data keyed by deck id; usually a single entry.</summary>
+        [JsonPropertyName("CustomDeck")]
+        public Dictionary<string, TtsCustomDeckEntry> CustomDeck { get; set; }
+
+        /// <summary>Present on deck piles; the cards contained in the pile.</summary>
+        [JsonPropertyName("ContainedObjects")]
+        public List<TtsObject> ContainedObjects { get; set; }
+
+        /// <summary>
+        /// Alternate faces keyed by state id; present on cards with content on
+        /// the back face (modal / flip cards).
+        /// </summary>
+        [JsonPropertyName("States")]
+        public Dictionary<string, TtsObject> States { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; set; }
+
+        /// <summary>True when this object is a pile of cards rather than a single card.</summary>
+        [JsonIgnore]
+        public bool IsDeck => ContainedObjects != null;
+    }
+
+    /// <summary>A single CustomDeck entry: the front/back image URLs for a card.</summary>
+    public class TtsCustomDeckEntry
+    {
+        [JsonPropertyName("FaceURL")]
+        public string FaceURL { get; set; }
+
+        [JsonPropertyName("BackURL")]
+        public string BackURL { get; set; }
+
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> ExtraData { get; set; }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/TtsDeckBuilder.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/TtsDeckBuilder.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace TTSDeckEditAndCreationTool.Model
+{
+    /// <summary>
+    /// Builds a Tabletop Simulator "Saved Object" from a resolved decklist (the
+    /// generation flow: decklist -> Scryfall -> art choice -> JSON). Each card gets
+    /// an individual image (NumWidth=1, NumHeight=1, one CustomDeck entry), so there
+    /// is no composite sheet and no per-card URL collision to worry about.
+    ///
+    /// Layout (per the user's choice, everything in one pile):
+    ///   ObjectStates[0] = DeckCustom pile
+    ///     CustomDeck : { "1": img1, "2": img2, ... }   one entry per UNIQUE card
+    ///     DeckIDs    : [100, 100, 200, ...]            CardID repeated per copy (quantity)
+    ///     ContainedObjects : one CardCustom per copy, sharing the unique image
+    ///   A single card (1 card x1) is emitted directly as a CardCustom, with no pile.
+    ///
+    /// Double-faced/modal cards (DeckCard.BackFaceURL set) carry their verso in
+    /// States["2"], mirroring tts-deckconverter (tts/builder.go).
+    /// Mirrors that reference's structure and default transforms/scales.
+    /// </summary>
+    public static class TtsDeckBuilder
+    {
+        // Standard MTG card scaling: TTS cards are ~56x80mm at scale 1, real cards are
+        // 63.5x88.9mm. Same constants as the reference (tts/builder.go).
+        private const double StandardScaleX = 63.5 / 56.0;
+        private const double StandardScaleZ = 88.9 / 80.0;
+
+        public static GenSavedObject Build(IEnumerable<DeckCard> cards, string backUrl, string saveName = "Generated Deck")
+        {
+            backUrl = UpgradeUrlToPng(backUrl);
+
+            // Expand to (uniqueCard, copies). The incoming DeckCards are already deduped
+            // by name with a Count, which is exactly one CustomDeck entry per unique image.
+            List<DeckCard> unique = cards?.Where(c => c != null && !string.IsNullOrWhiteSpace(c.FaceURL)).ToList()
+                                    ?? new List<DeckCard>();
+
+            int totalCopies = unique.Sum(c => c.Count <= 0 ? 1 : c.Count);
+
+            // Single card, single copy -> emit a lone CardCustom (no pile), like the reference.
+            if (unique.Count == 1 && totalCopies == 1)
+            {
+                DeckCard only = unique[0];
+                GenObject single = BuildCardObject(only, 100, "1", backUrl, isInsideDeck: false);
+                return new GenSavedObject { SaveName = saveName, ObjectStates = { single } };
+            }
+
+            var deck = new GenObject
+            {
+                Name = "DeckCustom",
+                Nickname = saveName,
+                Transform = new GenTransform
+                {
+                    RotY = 180,
+                    RotZ = 180,
+                    ScaleX = StandardScaleX,
+                    ScaleY = 1,
+                    ScaleZ = StandardScaleZ
+                },
+                ColorDiffuse = new GenColorDiffuse(),
+                CustomDeck = new Dictionary<string, GenCustomDeck>(),
+                DeckIDs = new List<int>(),
+                ContainedObjects = new List<GenObject>()
+            };
+
+            int n = 1;
+            foreach (DeckCard card in unique)
+            {
+                int copies = card.Count <= 0 ? 1 : card.Count;
+                int cardId = 100 * n;
+                string deckIdKey = n.ToString();
+
+                deck.CustomDeck[deckIdKey] = new GenCustomDeck
+                {
+                    FaceURL = UpgradeUrlToPng(card.FaceURL),
+                    BackURL = backUrl
+                };
+
+                for (int i = 0; i < copies; i++)
+                {
+                    deck.DeckIDs.Add(cardId);
+                    deck.ContainedObjects.Add(BuildCardObject(card, cardId, deckIdKey, backUrl, isInsideDeck: true));
+                }
+
+                n++;
+            }
+
+            return new GenSavedObject { SaveName = saveName, ObjectStates = { deck } };
+        }
+
+        private static GenObject BuildCardObject(DeckCard card, int cardId, string deckIdKey, string backUrl, bool isInsideDeck)
+        {
+            var obj = new GenObject
+            {
+                Name = "CardCustom",
+                Nickname = card.Cardname ?? card.Nickname ?? "",
+                Transform = new GenTransform
+                {
+                    RotY = 180,
+                    RotZ = 0,
+                    ScaleX = StandardScaleX,
+                    ScaleY = 1,
+                    ScaleZ = StandardScaleZ
+                },
+                ColorDiffuse = new GenColorDiffuse(),
+                CardID = cardId,
+                CustomDeck = new Dictionary<string, GenCustomDeck>
+                {
+                    [deckIdKey] = new GenCustomDeck
+                    {
+                        FaceURL = UpgradeUrlToPng(card.FaceURL),
+                        BackURL = backUrl
+                    }
+                }
+            };
+
+            // Double-faced/modal card: emit the verso as a self-contained state keyed "2".
+            // The state has its own CardID/CustomDeck (sheet 1, index 0), isolated from the
+            // parent deck — mirrors the reference's recursive alternate-state build.
+            if (!string.IsNullOrWhiteSpace(card.BackFaceURL))
+            {
+                obj.States = new Dictionary<string, GenObject>
+                {
+                    ["2"] = new GenObject
+                    {
+                        Name = "CardCustom",
+                        Nickname = card.Cardname ?? card.Nickname ?? "",
+                        Transform = new GenTransform
+                        {
+                            RotY = 180,
+                            RotZ = 0,
+                            ScaleX = StandardScaleX,
+                            ScaleY = 1,
+                            ScaleZ = StandardScaleZ
+                        },
+                        ColorDiffuse = new GenColorDiffuse(),
+                        CardID = 100,
+                        CustomDeck = new Dictionary<string, GenCustomDeck>
+                        {
+                            ["1"] = new GenCustomDeck
+                            {
+                                FaceURL = UpgradeUrlToPng(card.BackFaceURL),
+                                BackURL = backUrl
+                            }
+                        }
+                    }
+                };
+            }
+
+            return obj;
+        }
+
+        // Prefer Scryfall's full-resolution PNG over the smaller jpg variants.
+        // Mirrors DeckBuilderViewModel.UpgradeUrlToPng (kept here so the Model layer
+        // has no dependency on the ViewModel layer).
+        private static string UpgradeUrlToPng(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return url;
+            url = Regex.Replace(url, "/(small|normal|large)/", "/png/");
+            url = Regex.Replace(url, "\\.jpg", ".png");
+            return url;
+        }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/TtsGenerationModels.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Model/TtsGenerationModels.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace TTSDeckEditAndCreationTool.Model
+{
+    /// <summary>
+    /// Write-only DTOs used to GENERATE a Tabletop Simulator "Saved Object" JSON
+    /// from scratch (decklist -> JSON). These are intentionally separate from the
+    /// import-side <see cref="TtsSaveFile"/>/<see cref="TtsObject"/> models: those
+    /// are round-trip-safe (JsonExtensionData) for editing files we did not write,
+    /// whereas here we emit a full, self-contained object with every field TTS
+    /// expects and sensible defaults. Field names/shape mirror the reference
+    /// implementation (tts-deckconverter, tts/structs.go).
+    ///
+    /// Serialize with DefaultIgnoreCondition = WhenWritingNull so the nullable
+    /// members below behave like the reference's `omitempty` (e.g. a card has no
+    /// DeckIDs/ContainedObjects, a deck has no CardID).
+    /// </summary>
+    public class GenSavedObject
+    {
+        [JsonPropertyName("SaveName")] public string SaveName { get; set; } = "";
+        [JsonPropertyName("GameMode")] public string GameMode { get; set; } = "";
+        [JsonPropertyName("Date")] public string Date { get; set; } = "";
+        [JsonPropertyName("VersionNumber")] public string VersionNumber { get; set; } = "";
+        [JsonPropertyName("GameType")] public string GameType { get; set; } = "";
+        [JsonPropertyName("GameComplexity")] public string GameComplexity { get; set; } = "";
+        [JsonPropertyName("Table")] public string Table { get; set; } = "";
+        [JsonPropertyName("Sky")] public string Sky { get; set; } = "";
+        [JsonPropertyName("Note")] public string Note { get; set; } = "";
+        [JsonPropertyName("Rules")] public string Rules { get; set; } = "";
+        [JsonPropertyName("ObjectStates")] public List<GenObject> ObjectStates { get; set; } = new List<GenObject>();
+    }
+
+    public class GenObject
+    {
+        /// <summary>"DeckCustom" for a pile, "CardCustom" for a single card.</summary>
+        [JsonPropertyName("Name")] public string Name { get; set; }
+        [JsonPropertyName("Transform")] public GenTransform Transform { get; set; }
+        [JsonPropertyName("Nickname")] public string Nickname { get; set; } = "";
+        [JsonPropertyName("Description")] public string Description { get; set; } = "";
+        [JsonPropertyName("GMNotes")] public string GMNotes { get; set; } = "";
+        [JsonPropertyName("ColorDiffuse")] public GenColorDiffuse ColorDiffuse { get; set; }
+        [JsonPropertyName("Locked")] public bool Locked { get; set; }
+        [JsonPropertyName("Grid")] public bool Grid { get; set; } = true;
+        [JsonPropertyName("Snap")] public bool Snap { get; set; } = true;
+        [JsonPropertyName("IgnoreFoW")] public bool IgnoreFoW { get; set; }
+        [JsonPropertyName("MeasureMovement")] public bool MeasureMovement { get; set; }
+        [JsonPropertyName("DragSelectable")] public bool DragSelectable { get; set; } = true;
+        [JsonPropertyName("Autoraise")] public bool Autoraise { get; set; } = true;
+        [JsonPropertyName("Sticky")] public bool Sticky { get; set; } = true;
+        [JsonPropertyName("Tooltip")] public bool Tooltip { get; set; } = true;
+        [JsonPropertyName("GridProjection")] public bool GridProjection { get; set; }
+        [JsonPropertyName("HideWhenFaceDown")] public bool HideWhenFaceDown { get; set; } = true;
+        [JsonPropertyName("Hands")] public bool Hands { get; set; } = true;
+
+        /// <summary>Present on cards; absent (null) on the deck pile.</summary>
+        [JsonPropertyName("CardID")] public int? CardID { get; set; }
+        [JsonPropertyName("SidewaysCard")] public bool SidewaysCard { get; set; }
+
+        /// <summary>Present on the deck pile (one entry per card copy); null on a card.</summary>
+        [JsonPropertyName("DeckIDs")] public List<int> DeckIDs { get; set; }
+        /// <summary>Image data keyed by deck id (one entry per unique image).</summary>
+        [JsonPropertyName("CustomDeck")] public Dictionary<string, GenCustomDeck> CustomDeck { get; set; }
+
+        [JsonPropertyName("XmlUI")] public string XmlUI { get; set; } = "";
+        [JsonPropertyName("LuaScript")] public string LuaScript { get; set; } = "";
+        [JsonPropertyName("LuaScriptState")] public string LuaScriptState { get; set; } = "";
+
+        /// <summary>Present on the deck pile; null on a card.</summary>
+        [JsonPropertyName("ContainedObjects")] public List<GenObject> ContainedObjects { get; set; }
+        /// <summary>Verso of a double-faced card, keyed "2"; null otherwise.</summary>
+        [JsonPropertyName("States")] public Dictionary<string, GenObject> States { get; set; }
+
+        [JsonPropertyName("GUID")] public string GUID { get; set; } = "";
+    }
+
+    public class GenTransform
+    {
+        [JsonPropertyName("posX")] public double PosX { get; set; }
+        [JsonPropertyName("posY")] public double PosY { get; set; }
+        [JsonPropertyName("posZ")] public double PosZ { get; set; }
+        [JsonPropertyName("rotX")] public double RotX { get; set; }
+        [JsonPropertyName("rotY")] public double RotY { get; set; } = 180;
+        [JsonPropertyName("rotZ")] public double RotZ { get; set; }
+        [JsonPropertyName("scaleX")] public double ScaleX { get; set; } = 1;
+        [JsonPropertyName("scaleY")] public double ScaleY { get; set; } = 1;
+        [JsonPropertyName("scaleZ")] public double ScaleZ { get; set; } = 1;
+    }
+
+    public class GenColorDiffuse
+    {
+        [JsonPropertyName("r")] public double Red { get; set; } = 0.713235259;
+        [JsonPropertyName("g")] public double Green { get; set; } = 0.713235259;
+        [JsonPropertyName("b")] public double Blue { get; set; } = 0.713235259;
+    }
+
+    public class GenCustomDeck
+    {
+        [JsonPropertyName("FaceURL")] public string FaceURL { get; set; }
+        [JsonPropertyName("BackURL")] public string BackURL { get; set; }
+        [JsonPropertyName("NumWidth")] public int NumWidth { get; set; } = 1;
+        [JsonPropertyName("NumHeight")] public int NumHeight { get; set; } = 1;
+        [JsonPropertyName("BackIsHidden")] public bool BackIsHidden { get; set; } = true;
+        [JsonPropertyName("UniqueBack")] public bool UniqueBack { get; set; }
+        /// <summary>0 = rounded rectangle, 1 = rectangle (DeckShape).</summary>
+        [JsonPropertyName("Type")] public int Type { get; set; }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Store/CardStyleCache.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Store/CardStyleCache.cs
@@ -21,6 +21,14 @@ namespace TTSDeckEditAndCreationTool.Store
         static string FolderPath = Path.Combine(systemPath, "DEACT");
         static string SavePath = Path.Combine(systemPath, "DEACT\\DEACT_CardStyleCache.txt");
 
+        // --- Face URL cache: (cardname, lang, face) -> resolved Scryfall image url ---
+        // Scryfall asks clients to cache results for >=24h. This lets re-imports and
+        // Re-DL of the same cards skip the network (and the 2 req/s search rate limit)
+        // entirely. Only successful lookups are cached.
+        static string FaceCachePath = Path.Combine(systemPath, "DEACT\\DEACT_FaceCache.json");
+        static readonly TimeSpan FaceCacheTtl = TimeSpan.FromHours(24);
+        static Dictionary<string, CachedFace> FaceCache = new Dictionary<string, CachedFace>();
+
         public static void Initialize()
         {
             //Create folder
@@ -49,6 +57,63 @@ namespace TTSDeckEditAndCreationTool.Store
                     File.Delete(SavePath);
                 }
             }
+
+            //Load the face cache (best effort; a corrupt file is just discarded)
+            try
+            {
+                if (File.Exists(FaceCachePath))
+                {
+                    string stored = File.ReadAllText(FaceCachePath);
+                    FaceCache = JsonSerializer.Deserialize<Dictionary<string, CachedFace>>(stored)
+                                ?? new Dictionary<string, CachedFace>();
+                }
+            }
+            catch
+            {
+                FaceCache = new Dictionary<string, CachedFace>();
+            }
+        }
+
+        // setCode is part of the key: art from set "fin" must not collide with the
+        // default (any-set) lookup for the same card/language/face.
+        private static string FaceKey(string cardName, string lang, bool isBack, string setCode)
+            => $"{lang}|{(isBack ? "B" : "F")}|{setCode ?? ""}|{cardName}";
+
+        /// <summary>Returns a non-expired cached image url for this card/lang/face/set, or null.</summary>
+        public static string GetCachedFace(string cardName, string lang, bool isBack, string setCode = null)
+        {
+            if (FaceCache.TryGetValue(FaceKey(cardName, lang, isBack, setCode), out CachedFace entry))
+            {
+                if (DateTime.UtcNow - entry.FetchedUtc < FaceCacheTtl)
+                {
+                    return entry.Url;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>Caches a successful image url lookup (in memory; call SaveFaceCache to persist).</summary>
+        public static void StoreCachedFace(string cardName, string lang, bool isBack, string url, string setCode = null)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return;
+            FaceCache[FaceKey(cardName, lang, isBack, setCode)] = new CachedFace
+            {
+                Url = url,
+                FetchedUtc = DateTime.UtcNow
+            };
+        }
+
+        /// <summary>Persists the face cache to disk. Call once after a bulk fetch.</summary>
+        public static void SaveFaceCache()
+        {
+            try
+            {
+                File.WriteAllText(FaceCachePath, JsonSerializer.Serialize(FaceCache));
+            }
+            catch
+            {
+                // non-fatal: cache is an optimization, not source of truth
+            }
         }
 
         public static void SaveList()
@@ -61,6 +126,13 @@ namespace TTSDeckEditAndCreationTool.Store
         public static void DeleteCacheFile()
         {
             File.Delete(SavePath);
+        }
+
+        /// <summary>One cached face-url lookup with the time it was fetched (for TTL).</summary>
+        public class CachedFace
+        {
+            public string Url { get; set; }
+            public DateTime FetchedUtc { get; set; }
         }
 
         public static string DownloadImageIfNeeded(string url)

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Store/SetCatalog.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/Store/SetCatalog.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using TTSDeckEditAndCreationTool.Model;
+
+namespace TTSDeckEditAndCreationTool.Store
+{
+    /// <summary>
+    /// Loads and caches the list of Magic sets from Scryfall's /sets endpoint.
+    /// /sets is a "light" endpoint and a single call returns every set, so we fetch
+    /// once and cache to disk for 24h (per Scryfall's caching guidance). Used to
+    /// populate the series picker on the import and deck-builder screens.
+    /// </summary>
+    public static class SetCatalog
+    {
+        private static readonly HttpClient _http = CreateClient();
+        private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
+
+        private static readonly string CachePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "DEACT", "DEACT_Sets.json");
+
+        private static List<MagicSet> _sets;
+        private static readonly System.Threading.SemaphoreSlim _loadGate = new System.Threading.SemaphoreSlim(1, 1);
+
+        public static IReadOnlyList<MagicSet> Sets => _sets ?? new List<MagicSet>();
+
+        private static HttpClient CreateClient()
+        {
+            var c = new HttpClient();
+            c.DefaultRequestHeaders.Add("User-Agent", "DEACT/1.0 (contact@example.com)");
+            c.DefaultRequestHeaders.Add("Accept", "application/json");
+            return c;
+        }
+
+        /// <summary>
+        /// Ensures the set list is available: returns the in-memory copy, else a fresh
+        /// disk cache (&lt;24h), else fetches from Scryfall. Safe to call repeatedly.
+        /// </summary>
+        public static async Task EnsureLoadedAsync()
+        {
+            if (_sets != null) return;
+
+            await _loadGate.WaitAsync();
+            try
+            {
+                if (_sets != null) return;
+
+                if (TryLoadFromDisk(out List<MagicSet> cached))
+                {
+                    _sets = cached;
+                    return;
+                }
+
+                _sets = await FetchFromScryfallAsync() ?? new List<MagicSet>();
+            }
+            finally
+            {
+                _loadGate.Release();
+            }
+        }
+
+        private static bool TryLoadFromDisk(out List<MagicSet> sets)
+        {
+            sets = null;
+            try
+            {
+                if (!File.Exists(CachePath)) return false;
+                if (DateTime.UtcNow - File.GetLastWriteTimeUtc(CachePath) > CacheTtl) return false;
+
+                string json = File.ReadAllText(CachePath);
+                sets = JsonSerializer.Deserialize<List<MagicSet>>(json);
+                return sets != null && sets.Count > 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static async Task<List<MagicSet>> FetchFromScryfallAsync()
+        {
+            try
+            {
+                using HttpResponseMessage res = await _http.GetAsync("https://api.scryfall.com/sets");
+                if (!res.IsSuccessStatusCode) return null;
+
+                string data = await res.Content.ReadAsStringAsync();
+                using JsonDocument doc = JsonDocument.Parse(data);
+                if (!doc.RootElement.TryGetProperty("data", out JsonElement arr) || arr.ValueKind != JsonValueKind.Array)
+                    return null;
+
+                var list = new List<MagicSet>();
+                foreach (JsonElement e in arr.EnumerateArray())
+                {
+                    list.Add(new MagicSet
+                    {
+                        Code = e.TryGetProperty("code", out var c) ? c.GetString() : null,
+                        Name = e.TryGetProperty("name", out var n) ? n.GetString() : null,
+                        ReleasedAt = e.TryGetProperty("released_at", out var r) ? r.GetString() : null,
+                        SetType = e.TryGetProperty("set_type", out var t) ? t.GetString() : null
+                    });
+                }
+
+                // newest first so the most relevant series sit at the top of the picker
+                list = list.OrderByDescending(s => s.ReleasedAt ?? "").ToList();
+
+                TrySaveToDisk(list);
+                return list;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void TrySaveToDisk(List<MagicSet> sets)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(CachePath));
+                File.WriteAllText(CachePath, JsonSerializer.Serialize(sets));
+            }
+            catch
+            {
+                // non-fatal: catalog will simply be refetched next time
+            }
+        }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/CardBuilderView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/CardBuilderView.xaml
@@ -32,6 +32,22 @@
             <!-- TargetNullValue avoids an ImageSourceConverter warning while FaceURL is still null during load -->
             <Image Grid.Row="1" Source="{Binding Card.FaceURL, TargetNullValue={x:Null}, FallbackValue={x:Null}}" RenderOptions.BitmapScalingMode="HighQuality"/>
 
+            <!-- Double-faced badge (top-left over the art): flips to a back face via States in TTS -->
+            <Border Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="8"
+                    Background="#CC1565C0" CornerRadius="3" Padding="5,2"
+                    Visibility="{Binding IsDoubleFaced, Converter={StaticResource BoolToVis}}"
+                    ToolTip="Double-faced card — flips to its back face in TTS.">
+                <TextBlock Text="⇄ R/V" Foreground="White" FontSize="12" FontWeight="Bold"/>
+            </Border>
+
+            <!-- Language fallback badge (top-right over the art): art is not in the preferred language -->
+            <Border Grid.Row="1" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="8"
+                    Background="#CCB8860B" CornerRadius="3" Padding="5,2"
+                    Visibility="{Binding ShowLanguageWarning, Converter={StaticResource BoolToVis}}"
+                    ToolTip="{Binding LanguageTooltip}">
+                <TextBlock Text="{Binding LanguageWarning}" Foreground="White" FontSize="12" FontWeight="Bold"/>
+            </Border>
+
             <Grid Grid.Row="2">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition/>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/CardBuilderView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/CardBuilderView.xaml
@@ -4,8 +4,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:TTSDeckEditAndCreationTool.View"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              Height="420" Width="340">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </UserControl.Resources>
     <Border BorderThickness="1" BorderBrush="{StaticResource MainLight}" Margin="5" CornerRadius="5" Background="{StaticResource MainMid}" MouseEnter="Border_MouseEnter" MouseLeave="Border_MouseLeave">
         <Grid>
             <Grid.RowDefinitions>
@@ -16,7 +19,18 @@
 
             <Label Foreground="White" Content="{Binding Card.Cardname, FallbackValue=KamiOfTheCrescentMoon}" Style="{StaticResource BoldLabel}" FontSize="14"/>
 
-            <Image Grid.Row="1" Source="{Binding Card.FaceURL}" RenderOptions.BitmapScalingMode="HighQuality"/>
+            <!-- Status dot: orange = no art in selected language, red = fetch error/rate-limited -->
+            <Ellipse Grid.Row="0" Width="14" Height="14" Margin="0,4,8,0" HorizontalAlignment="Right" VerticalAlignment="Top"
+                     Fill="#FFA500" Stroke="#33000000" StrokeThickness="1"
+                     Visibility="{Binding ShowNotFoundIcon, Converter={StaticResource BoolToVis}}"
+                     ToolTip="{Binding StatusTooltip}"/>
+            <Ellipse Grid.Row="0" Width="14" Height="14" Margin="0,4,8,0" HorizontalAlignment="Right" VerticalAlignment="Top"
+                     Fill="#E53935" Stroke="#33000000" StrokeThickness="1"
+                     Visibility="{Binding ShowErrorIcon, Converter={StaticResource BoolToVis}}"
+                     ToolTip="{Binding StatusTooltip}"/>
+
+            <!-- TargetNullValue avoids an ImageSourceConverter warning while FaceURL is still null during load -->
+            <Image Grid.Row="1" Source="{Binding Card.FaceURL, TargetNullValue={x:Null}, FallbackValue={x:Null}}" RenderOptions.BitmapScalingMode="HighQuality"/>
 
             <Grid Grid.Row="2">
                 <Grid.ColumnDefinitions>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DeckBuilderView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DeckBuilderView.xaml
@@ -17,7 +17,15 @@
             <RowDefinition Height="30"/>
         </Grid.RowDefinitions>
 
-        <Button Style="{DynamicResource FlatButtonStyle}" Height="25" Background="{StaticResource Good}" Content="Save" Width="100" HorizontalAlignment="Right" Margin="5" Command="{Binding SaveDeckCommand}" IsEnabled="{Binding IsNotBusy}"/>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,5,0">
+            <Border Background="{StaticResource MainLight}" CornerRadius="3" Padding="8,3" Margin="0,0,8,0"
+                    VerticalAlignment="Center"
+                    ToolTip="Total cards counting duplicates (unique cards in parentheses)">
+                <TextBlock Text="{Binding DeckCountSummary}" Foreground="White" VerticalAlignment="Center"
+                           FontFamily="{StaticResource CoreFont}"/>
+            </Border>
+            <Button Style="{DynamicResource FlatButtonStyle}" Height="25" Background="{StaticResource Good}" Content="Save" Width="100" Margin="5" Command="{Binding SaveDeckCommand}" IsEnabled="{Binding IsNotBusy}"/>
+        </StackPanel>
         <StackPanel Orientation="Horizontal">
             <Label Style="{DynamicResource BoldLabel}" VerticalAlignment="Center">Card Back URL:</Label>
             <TextBox Background="Transparent" Foreground="White" Text="{Binding CardBackURL}" Margin="10" Width="200" VerticalContentAlignment="Center"/>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DeckBuilderView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DeckBuilderView.xaml
@@ -5,8 +5,11 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:TTSDeckEditAndCreationTool.View"
              xmlns:views ="clr-namespace:TTSDeckEditAndCreationTool.View"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="50"/>
@@ -14,7 +17,7 @@
             <RowDefinition Height="30"/>
         </Grid.RowDefinitions>
 
-        <Button Style="{DynamicResource FlatButtonStyle}" Height="25" Background="{StaticResource Good}" Content="Save" Width="100" HorizontalAlignment="Right" Margin="5" Command="{Binding SaveDeckCommand}"/>
+        <Button Style="{DynamicResource FlatButtonStyle}" Height="25" Background="{StaticResource Good}" Content="Save" Width="100" HorizontalAlignment="Right" Margin="5" Command="{Binding SaveDeckCommand}" IsEnabled="{Binding IsNotBusy}"/>
         <StackPanel Orientation="Horizontal">
             <Label Style="{DynamicResource BoldLabel}" VerticalAlignment="Center">Card Back URL:</Label>
             <TextBox Background="Transparent" Foreground="White" Text="{Binding CardBackURL}" Margin="10" Width="200" VerticalContentAlignment="Center"/>
@@ -22,7 +25,35 @@
             <Label Grid.Row="2" Foreground="White" VerticalAlignment="Center" FontFamily="{StaticResource LightFont}" Margin="5" Content="{Binding ImportSummary}"/>
             <Label Style="{DynamicResource BoldLabel}" VerticalAlignment="Center" Margin="10,0,0,0">Sets:</Label>
             <TextBox Background="Transparent" Foreground="White" Text="{Binding SetAbbreviations}" Margin="5" Width="100" VerticalContentAlignment="Center"/>
-            <Button Style="{DynamicResource FlatButtonStyle}" Height="25" Background="{StaticResource Good}" Content="Apply" Width="80" Command="{Binding ApplySetStylesCommand}" Margin="5"/>
+            <Button Style="{DynamicResource FlatButtonStyle}" Height="25" Background="{StaticResource Good}" Content="Apply" Width="80" Command="{Binding ApplySetStylesCommand}" Margin="5" IsEnabled="{Binding IsNotBusy}"/>
+            <Button Style="{DynamicResource FlatButtonStyle}" Height="25" Background="{StaticResource Good}" Content="{Binding RefetchLanguageButtonText}" MinWidth="80" Command="{Binding RefetchLanguageCommand}" Margin="5" IsEnabled="{Binding IsNotBusy}" ToolTip="Re-download all card art in the selected language"/>
+            <Label Style="{DynamicResource BoldLabel}" VerticalAlignment="Center" Margin="10,0,0,0">Series:</Label>
+            <ComboBox Width="180" Height="25" VerticalAlignment="Center" Foreground="Black" Background="{StaticResource MainLight}"
+                      IsEditable="True" IsTextSearchEnabled="False" StaysOpenOnEdit="True" IsEnabled="{Binding IsNotBusy}"
+                      ItemsSource="{Binding SetSelector.FilteredSets}"
+                      DisplayMemberPath="Display"
+                      Text="{Binding SetSelector.SearchText, UpdateSourceTrigger=PropertyChanged}"
+                      SelectedItem="{Binding SetSelector.ComboSelection}"
+                      ToolTip="Type to search, pick one or more series, then Re-DL (empty = any set)"/>
+            <ItemsControl ItemsSource="{Binding SetSelector.SelectedSets}" VerticalAlignment="Center" Margin="4,0,0,0">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Background="{StaticResource Good}" CornerRadius="3" Margin="0,0,4,0" Padding="6,2">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Code}" Foreground="White" VerticalAlignment="Center"/>
+                                <Button Content="✕" Margin="6,0,0,0" Padding="2,0" FontSize="10" Foreground="White"
+                                        Background="Transparent" BorderThickness="0" Cursor="Hand"
+                                        Command="{Binding DataContext.SetSelector.RemoveSetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        CommandParameter="{Binding}"/>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <Label Foreground="White" VerticalAlignment="Center" FontFamily="{StaticResource LightFont}" Margin="5" Content="{Binding FetchStatus}"/>
         </StackPanel>
 
         <ScrollViewer Grid.Row="1" Background="Transparent" VerticalScrollBarVisibility="Auto">
@@ -41,5 +72,14 @@
         </ScrollViewer>
 
         <Rectangle Grid.Row="2" Fill="{StaticResource MainLight}"/>
+
+        <!-- Loading overlay: covers the whole view during a bulk fetch (import / Re-DL) -->
+        <Border Grid.RowSpan="3" Background="#CC0B0C0F" Visibility="{Binding IsBusy, Converter={StaticResource BoolToVis}}">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding BusyText}" Foreground="White" FontSize="20" TextAlignment="Center"
+                           FontFamily="{StaticResource CoreFont}" LineHeight="30" LineStackingStrategy="BlockLineHeight"/>
+                <ProgressBar IsIndeterminate="True" Height="6" Width="320" Margin="0,18,0,0" Background="Transparent" Foreground="{StaticResource Good}"/>
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DecklistImportView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DecklistImportView.xaml
@@ -1,0 +1,81 @@
+<UserControl x:Class="TTSDeckEditAndCreationTool.View.DecklistImportView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:TTSDeckEditAndCreationTool.View"
+             xmlns:vm="clr-namespace:TTSDeckEditAndCreationTool.ViewModel"
+             mc:Ignorable="d"
+             d:DesignHeight="600" d:DesignWidth="800">
+    <Grid Background="#FF2D2D30">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Generate from Decklist" Foreground="White" FontSize="28"
+                   FontWeight="Bold" HorizontalAlignment="Center" Margin="0,20,0,5"/>
+
+        <!-- Decklist paste area -->
+        <Grid Grid.Row="1" Margin="20,5,20,5">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0" Foreground="#FFBBBBBB" Margin="2,0,0,4"
+                       Text="Paste a decklist (one card per line, e.g. &quot;1 Sol Ring (C21) 263&quot; or &quot;10 Forest&quot;):"/>
+            <TextBox Grid.Row="1"
+                     Text="{Binding DecklistText, UpdateSourceTrigger=PropertyChanged}"
+                     AcceptsReturn="True" AcceptsTab="False"
+                     TextWrapping="NoWrap"
+                     VerticalScrollBarVisibility="Auto"
+                     HorizontalScrollBarVisibility="Auto"
+                     FontFamily="Consolas" FontSize="13"
+                     Background="#FF1E1E1E" Foreground="White"/>
+        </Grid>
+
+        <!-- Language + series pickers -->
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="20,0,20,10" VerticalAlignment="Center">
+            <TextBlock Text="Language:" Foreground="White" VerticalAlignment="Center" Margin="0,0,6,0"/>
+            <ComboBox Width="150" Height="30" ItemsSource="{Binding Languages}"
+                      SelectedItem="{Binding SelectedLanguage}"/>
+
+            <TextBlock Text="Pin series (optional):" Foreground="White"
+                       VerticalAlignment="Center" Margin="20,0,6,0"/>
+            <ComboBox Width="220" Height="30"
+                      IsEditable="True" IsTextSearchEnabled="False" StaysOpenOnEdit="True"
+                      Text="{Binding SetSelector.SearchText, UpdateSourceTrigger=PropertyChanged}"
+                      ItemsSource="{Binding SetSelector.FilteredSets}"
+                      SelectedItem="{Binding SetSelector.ComboSelection}"
+                      DisplayMemberPath="Display"/>
+
+            <ItemsControl ItemsSource="{Binding SetSelector.SelectedSets}" Margin="10,0,0,0" VerticalAlignment="Center">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel/>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Background="#FF3F3F46" CornerRadius="3" Margin="3" Padding="6,3">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Display}" Foreground="White" VerticalAlignment="Center"/>
+                                <Button Content="✕" Margin="6,0,0,0" Padding="0"
+                                        Command="{Binding DataContext.SetSelector.RemoveSetCommand,
+                                                  RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        CommandParameter="{Binding}"/>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
+
+        <!-- Generate -->
+        <Button Grid.Row="3" Content="Generate Deck" Command="{Binding GenerateCommand}"
+                Width="200" Height="40" Margin="0,0,0,20" FontSize="18"
+                HorizontalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DecklistImportView.xaml.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/DecklistImportView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace TTSDeckEditAndCreationTool.View
+{
+    public partial class DecklistImportView : UserControl
+    {
+        public DecklistImportView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/HomeView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/HomeView.xaml
@@ -19,6 +19,7 @@
                 <ColumnDefinition></ColumnDefinition>
                 <ColumnDefinition></ColumnDefinition>
                 <ColumnDefinition></ColumnDefinition>
+                <ColumnDefinition></ColumnDefinition>
             </Grid.ColumnDefinitions>
             <StackPanel VerticalAlignment="Center" Grid.Column="0">
                 <Button Command="{Binding SwitchToDeckImportCommand}" Style="{DynamicResource ImageButton}" BorderThickness="0" Width="200">
@@ -26,13 +27,19 @@
                 </Button>
                 <Label Foreground="White" HorizontalAlignment="Center" FontFamily="{StaticResource BigFont}" FontSize="20">Import</Label>
             </StackPanel>
-            <StackPanel VerticalAlignment="Center"  Grid.Column="1">
+            <StackPanel VerticalAlignment="Center" Grid.Column="1">
+                <Button Command="{Binding SwitchToDeckGenerateCommand}" Style="{DynamicResource ImageButton}" BorderThickness="0" Width="200">
+                    <Image Source="..\Images\add-file-512.png" Margin="20" RenderOptions.BitmapScalingMode="HighQuality"/>
+                </Button>
+                <Label Foreground="White" HorizontalAlignment="Center" FontFamily="{StaticResource BigFont}" FontSize="20">Generate</Label>
+            </StackPanel>
+            <StackPanel VerticalAlignment="Center"  Grid.Column="2">
                 <Button Command="{Binding SwitchToDeckMergeCommand}"  Style="{DynamicResource ImageButton}" BorderThickness="0" Width="200">
                     <Image Source="..\Images\add-file-512.png" Margin="20" RenderOptions.BitmapScalingMode="HighQuality"/>
                 </Button>
                 <Label Foreground="White" HorizontalAlignment="Center" FontFamily="{StaticResource BigFont}" FontSize="20">Merge</Label>
             </StackPanel>
-            <StackPanel VerticalAlignment="Center" Grid.Column="2">
+            <StackPanel VerticalAlignment="Center" Grid.Column="3">
                 <Button Command="{Binding SwitchToQBGCommand}" Style="{DynamicResource ImageButton}" BorderThickness="0" Width="200">
                     <Image Source="..\Images\picture-2-512.png" Margin="20" RenderOptions.BitmapScalingMode="HighQuality"/>
                 </Button>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/ImportDeckView.xaml
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/View/ImportDeckView.xaml
@@ -4,10 +4,11 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:TTSDeckEditAndCreationTool.View"
-             mc:Ignorable="d" 
-             Height="200" Width="400">
+             mc:Ignorable="d"
+             Height="240" Width="400">
     <Grid>
         <Grid.RowDefinitions>
+            <RowDefinition/>
             <RowDefinition/>
             <RowDefinition/>
         </Grid.RowDefinitions>
@@ -35,5 +36,35 @@
             <ComboBoxItem>Traditional Chinese</ComboBoxItem>
         </ComboBox>
         <Button Grid.Column="1" Grid.Row="1" Width="120" Height="30" Margin="150,0,0,0" HorizontalAlignment="Left" Style="{DynamicResource FlatButtonStyle}" Background="{StaticResource Good}" Command="{Binding ImportSelectedPathCommand}">Import</Button>
+
+        <Label Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,4,0,0" FontSize="13" Style="{DynamicResource BoldLabel}">Sets:</Label>
+        <StackPanel Grid.Column="1" Grid.Row="2" Margin="0,4,0,0">
+            <ComboBox Width="270" Height="28" HorizontalAlignment="Left"
+                      Foreground="Black" Background="{StaticResource MainLight}"
+                      IsEditable="True" IsTextSearchEnabled="False" StaysOpenOnEdit="True"
+                      ItemsSource="{Binding SetSelector.FilteredSets}"
+                      DisplayMemberPath="Display"
+                      Text="{Binding SetSelector.SearchText, UpdateSourceTrigger=PropertyChanged}"
+                      SelectedItem="{Binding SetSelector.ComboSelection}"
+                      ToolTip="Type to search, pick one or more series (leave empty for any set)"/>
+            <ItemsControl ItemsSource="{Binding SetSelector.SelectedSets}" Margin="0,4,0,0">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate><WrapPanel/></ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Background="{StaticResource Good}" CornerRadius="3" Margin="0,0,4,4" Padding="6,2">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Code}" Foreground="White" VerticalAlignment="Center"/>
+                                <Button Content="✕" Margin="6,0,0,0" Padding="2,0" FontSize="10" Foreground="White"
+                                        Background="Transparent" BorderThickness="0" Cursor="Hand"
+                                        Command="{Binding DataContext.SetSelector.RemoveSetCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                        CommandParameter="{Binding}"/>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
     </Grid>
 </UserControl>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/CardBuilderViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/CardBuilderViewModel.cs
@@ -16,6 +16,41 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
         public ICommand OrderOpenStyleWindow { get; set; }
 
+        private FetchOutcome _fetchStatus = FetchOutcome.Success;
+        /// <summary>Result of the last bulk fetch for this card; drives the warning/error icon.</summary>
+        public FetchOutcome FetchStatus
+        {
+            get => _fetchStatus;
+            set
+            {
+                _fetchStatus = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ShowNotFoundIcon));
+                OnPropertyChanged(nameof(ShowErrorIcon));
+                OnPropertyChanged(nameof(StatusTooltip));
+            }
+        }
+
+        /// <summary>Orange icon: no print exists for this card in the requested language.</summary>
+        public bool ShowNotFoundIcon => _fetchStatus == FetchOutcome.NotFound;
+
+        /// <summary>Red icon: the fetch failed (network/parse error or persistent rate-limit).</summary>
+        public bool ShowErrorIcon => _fetchStatus == FetchOutcome.Error || _fetchStatus == FetchOutcome.RateLimited;
+
+        public string StatusTooltip
+        {
+            get
+            {
+                switch (_fetchStatus)
+                {
+                    case FetchOutcome.NotFound: return "No art found in the selected language (kept previous image).";
+                    case FetchOutcome.RateLimited: return "Rate-limited by Scryfall — try again later.";
+                    case FetchOutcome.Error: return "Fetch failed (network or parse error).";
+                    default: return null;
+                }
+            }
+        }
+
         public CardBuilderViewModel(DeckCard card)
         {
             Card = card;

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/CardBuilderViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/CardBuilderViewModel.cs
@@ -51,6 +51,34 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             }
         }
 
+        /// <summary>True when this card carries a distinct back face (double-faced / modal),
+        /// i.e. the generator will emit it as a flippable card via States. Drives the DFC badge.</summary>
+        public bool IsDoubleFaced => Card != null && !string.IsNullOrWhiteSpace(Card.BackFaceURL);
+
+        private string _languageWarning;
+        /// <summary>
+        /// Upper-case language code (e.g. "EN") shown as a badge when the resolved art is NOT
+        /// in the preferred language — a heads-up that this card fell back. Null when it matched
+        /// the preferred language (or language is unknown).
+        /// </summary>
+        public string LanguageWarning
+        {
+            get => _languageWarning;
+            set
+            {
+                _languageWarning = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ShowLanguageWarning));
+                OnPropertyChanged(nameof(LanguageTooltip));
+            }
+        }
+
+        public bool ShowLanguageWarning => !string.IsNullOrEmpty(_languageWarning);
+
+        public string LanguageTooltip => ShowLanguageWarning
+            ? $"Art is in {_languageWarning}, not your preferred language."
+            : null;
+
         public CardBuilderViewModel(DeckCard card)
         {
             Card = card;
@@ -59,6 +87,9 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
             OrderOpenStyleWindow = new OpenCardStyleWindowCommand(this);
         }
+
+        /// <summary>Notifies the UI that the card's copy count changed (deduped duplicates).</summary>
+        public void NotifyCountChanged() => OnPropertyChanged(nameof(Card));
 
         public void UpdateCardFaceURL(string newFaceURL)
         {

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/DeckBuilderViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/DeckBuilderViewModel.cs
@@ -77,6 +77,15 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             }
         }
 
+        /// <summary>Total cards in the deck counting duplicates (e.g. 100 for a Commander deck).</summary>
+        public int TotalCardCount => _deckCards?.Sum(c => c.Card?.Count ?? 0) ?? 0;
+
+        /// <summary>Number of distinct cards (gallery tiles).</summary>
+        public int UniqueCardCount => _deckCards?.Count ?? 0;
+
+        /// <summary>Header label: "100 cards (89 unique)".</summary>
+        public string DeckCountSummary => $"{TotalCardCount} cards ({UniqueCardCount} unique)";
+
         public string CardBackURL
         {
             get
@@ -205,6 +214,10 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
         private string _deckPath { get; set; }
         private TtsSaveFile _save; //typed, round-trip-safe model of the loaded deck; the single source of truth for saving
+        // True when this deck was built from a decklist (generation mode) rather than
+        // imported from a TTS file. In that mode there is no _save to edit; Save builds
+        // a fresh Saved Object from DeckCards via TtsDeckBuilder. See LoadFromDecklist.
+        private bool _isGenerated;
         private string _oldCardBackURL { get; set; }
         private bool _isUpdated;
         public bool IsUpdated
@@ -326,6 +339,249 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             //PART 3 : LOAD ON SCREEN
             OnPropertyChanged(nameof(DeckCards));
             OnPropertyChanged(nameof(CardBackURL));
+            OnPropertyChanged(nameof(TotalCardCount));
+            OnPropertyChanged(nameof(UniqueCardCount));
+            OnPropertyChanged(nameof(DeckCountSummary));
+        }
+
+        /// <summary>
+        /// Generation flow: resolve a parsed decklist into on-screen cards (front + verso
+        /// images from Scryfall), then let the user tweak art in the same gallery. Saving
+        /// builds a fresh TTS Saved Object from these cards (see SaveDeckToPath).
+        /// </summary>
+        public async Task LoadFromDecklist(System.Collections.Generic.List<ParsedDeckLine> lines)
+        {
+            _isGenerated = true;
+            _save = null;
+            _deckPath = null;
+            IsUpdated = false;
+
+            DeckCards = new ObservableCollection<CardBuilderViewModel>();
+            CardLookup = new Dictionary<string, DeckCard>();
+            CardArt = new Dictionary<string, string>();
+
+            _preferredLanguageCount = 0;
+            _defaultLanguageCount = 0;
+            _errorCount = 0;
+            OnPropertyChanged(nameof(ImportSummary));
+
+            if (lines == null || lines.Count == 0)
+            {
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage("The decklist is empty or could not be parsed.");
+                return;
+            }
+
+            BeginBusy(lines.Count, "Resolving cards");
+            try
+            {
+                // Pinned series fill the cache in bulk first, just like the import flow.
+                await PreloadSelectedSetsAsync();
+
+                foreach (ParsedDeckLine line in lines)
+                {
+                    string name = line.Name;
+
+                    // Dedupe by name: a repeated card just bumps the count and shares one image.
+                    if (CardLookup.TryGetValue(name, out DeckCard existing))
+                    {
+                        existing.Count += line.Count;
+                        DeckCards.FirstOrDefault(c => c.Card == existing)?.NotifyCountChanged();
+                        OnPropertyChanged(nameof(TotalCardCount));
+                        OnPropertyChanged(nameof(DeckCountSummary));
+                        StepProgress();
+                        continue;
+                    }
+
+                    // One lookup yields BOTH faces (the Scryfall response carries card_faces),
+                    // so single-faced cards no longer pay for a wasted second back-face search.
+                    (FetchedImageResult front, string backUrl) = await ResolveDeckCardFaces(name, line.SetCode, line.CollectorNumber);
+                    FetchOutcome outcome = front.Outcome;
+                    string faceUrl = front?.Url;
+
+                    if (!string.IsNullOrWhiteSpace(faceUrl))
+                    {
+                        if (front.Language == PreferredLanguage) _preferredLanguageCount++;
+                        else if (front.Language == "en") _defaultLanguageCount++;
+                    }
+                    else
+                    {
+                        _errorCount++;
+                    }
+                    OnPropertyChanged(nameof(ImportSummary));
+
+                    var card = new DeckCard(name, 0, faceUrl, false, 'L', line.Count)
+                    {
+                        Cardname = name,
+                        SetCode = line.SetCode,
+                        CollectorNumber = line.CollectorNumber,
+                        BackFaceURL = backUrl
+                    };
+
+                    var temp = new CardBuilderViewModel(card) { FetchStatus = outcome };
+                    // Flag a non-preferred-language fallback (e.g. art only found in English).
+                    if (!string.IsNullOrWhiteSpace(faceUrl)
+                        && !string.IsNullOrWhiteSpace(front.Language)
+                        && front.Language != PreferredLanguage)
+                    {
+                        temp.LanguageWarning = front.Language.ToUpper();
+                    }
+                    CardLookup.Add(name, card);
+                    DeckCards.Add(temp);
+                    OnPropertyChanged(nameof(TotalCardCount));
+                    OnPropertyChanged(nameof(UniqueCardCount));
+                    OnPropertyChanged(nameof(DeckCountSummary));
+
+                    StepProgress();
+                }
+            }
+            catch (Exception e)
+            {
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage("Error resolving decklist \n\n" + e.Message);
+            }
+            finally
+            {
+                CardStyleCache.SaveFaceCache();
+                EndBusy();
+            }
+
+            FetchStatus = ImportSummary;
+            OnPropertyChanged(nameof(DeckCards));
+            OnPropertyChanged(nameof(TotalCardCount));
+            OnPropertyChanged(nameof(UniqueCardCount));
+            OnPropertyChanged(nameof(DeckCountSummary));
+        }
+
+        /// <summary>Front + optional back image resolved in a single Scryfall lookup.</summary>
+        private class CardFaces
+        {
+            public string Front;
+            public string Back;            // null for single-faced cards
+            public string Language;
+            public FetchOutcome Outcome;
+        }
+
+        /// <summary>
+        /// Resolves a card's front (and back, if double-faced) for the generation flow,
+        /// honoring (in priority order) the decklist line's pinned print "(SET) NUMBER",
+        /// then the user-selected series, then any set; each tried preferred language first,
+        /// then English. Both faces come from ONE search response, so a single-faced card
+        /// never pays for a separate back-face lookup.
+        ///
+        /// Performance: any set already bulk-loaded by <see cref="PreloadSelectedSetsAsync"/>
+        /// is resolved from the cache only — a cache miss there means the card simply isn't
+        /// in that set, so we skip the network for it instead of issuing a doomed request.
+        /// </summary>
+        private async Task<(FetchedImageResult front, string back)> ResolveDeckCardFaces(string name, string setCode, string collector)
+        {
+            string preferred = string.IsNullOrWhiteSpace(PreferredLanguage) ? "en" : PreferredLanguage;
+            List<string> languages = new[] { preferred, "en" }.Distinct().ToList();
+
+            var preloaded = new HashSet<string>(SetSelector?.SelectedSetCodes ?? new List<string>());
+
+            // Set priority: explicit pinned set, then pinned series, then "any set" (null).
+            List<string> sets = new List<string>();
+            if (!string.IsNullOrWhiteSpace(setCode)) sets.Add(setCode);
+            if (SetSelector?.SelectedSetCodes != null) sets.AddRange(SetSelector.SelectedSetCodes);
+            sets.Add(null);
+
+            bool sawRateLimit = false, sawError = false;
+            foreach (string set in sets)
+            {
+                foreach (string lang in languages)
+                {
+                    // The collector number only pins the explicit decklist set.
+                    string cn = (set == setCode && !string.IsNullOrWhiteSpace(setCode)) ? collector : null;
+                    // Preloaded set + no collector = cache is authoritative: skip the network.
+                    bool cacheOnly = set != null && string.IsNullOrWhiteSpace(cn) && preloaded.Contains(set);
+
+                    CardFaces r = await TryFetchFaces(name, lang, set, cn, cacheOnly);
+                    if (r.Outcome == FetchOutcome.Success)
+                        return (new FetchedImageResult { Url = r.Front, Language = r.Language, Outcome = FetchOutcome.Success }, r.Back);
+                    if (r.Outcome == FetchOutcome.RateLimited) sawRateLimit = true;
+                    else if (r.Outcome == FetchOutcome.Error) sawError = true;
+                }
+            }
+
+            return (new FetchedImageResult
+            {
+                Outcome = sawRateLimit ? FetchOutcome.RateLimited
+                        : sawError ? FetchOutcome.Error
+                        : FetchOutcome.NotFound
+            }, null);
+        }
+
+        /// <summary>
+        /// One Scryfall search for a (card, language[, set, collector]); extracts BOTH faces
+        /// from the response. Honors the face cache when no collector number is given. When
+        /// <paramref name="cacheOnly"/> is set, a cache miss returns NotFound without hitting
+        /// the network (used for sets already bulk-preloaded). The "no back" case relies on
+        /// the preload invariant: it caches a back face iff one exists, so a cached front with
+        /// no cached back means the card is single-faced.
+        /// </summary>
+        private async Task<CardFaces> TryFetchFaces(string cardName, string lang, string setCode, string collector, bool cacheOnly)
+        {
+            bool useCache = string.IsNullOrWhiteSpace(collector);
+            if (useCache)
+            {
+                string cf = CardStyleCache.GetCachedFace(cardName, lang, false, setCode);
+                if (!string.IsNullOrEmpty(cf))
+                {
+                    string cb = CardStyleCache.GetCachedFace(cardName, lang, true, setCode);
+                    return new CardFaces { Front = cf, Back = string.IsNullOrEmpty(cb) ? null : cb, Language = lang, Outcome = FetchOutcome.Success };
+                }
+                if (cacheOnly)
+                    return new CardFaces { Outcome = FetchOutcome.NotFound };
+            }
+
+            try
+            {
+                string q = "!" + cardName.Replace(' ', '_') + " lang:" + lang;
+                if (!string.IsNullOrWhiteSpace(setCode)) q += " set:" + setCode;
+                if (!string.IsNullOrWhiteSpace(collector)) q += " cn:" + collector;
+                string baseUrl = "https://api.scryfall.com/cards/search?q=" + q + "&unique=prints";
+
+                using HttpResponseMessage res = await GetWithRateLimitAsync(baseUrl);
+                if ((int)res.StatusCode == 429)
+                    return new CardFaces { Outcome = FetchOutcome.RateLimited };
+                if (!res.IsSuccessStatusCode)
+                    return new CardFaces { Outcome = FetchOutcome.Error };
+
+                string data = await res.Content.ReadAsStringAsync();
+                JsonElement root = JsonSerializer.Deserialize<JsonElement>(data);
+                if (root.TryGetProperty("data", out JsonElement cardInfos) && cardInfos.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (JsonElement cardInfo in cardInfos.EnumerateArray())
+                    {
+                        string front = null, back = null;
+                        if (cardInfo.TryGetProperty("image_uris", out JsonElement imgs))
+                        {
+                            front = PickNormal(imgs);
+                        }
+                        else if (cardInfo.TryGetProperty("card_faces", out JsonElement faces) && faces.ValueKind == JsonValueKind.Array)
+                        {
+                            var faceList = faces.EnumerateArray().ToList();
+                            if (faceList.Count > 0 && faceList[0].TryGetProperty("image_uris", out JsonElement f0))
+                                front = PickNormal(f0);
+                            if (faceList.Count > 1 && faceList[1].TryGetProperty("image_uris", out JsonElement f1))
+                                back = PickNormal(f1);
+                        }
+
+                        if (string.IsNullOrEmpty(front)) continue;
+                        if (useCache)
+                        {
+                            CardStyleCache.StoreCachedFace(cardName, lang, false, front, setCode);
+                            if (!string.IsNullOrEmpty(back))
+                                CardStyleCache.StoreCachedFace(cardName, lang, true, back, setCode);
+                        }
+                        return new CardFaces { Front = front, Back = back, Language = lang, Outcome = FetchOutcome.Success };
+                    }
+                }
+                return new CardFaces { Outcome = FetchOutcome.NotFound };
+            }
+            catch
+            {
+                return new CardFaces { Outcome = FetchOutcome.Error };
+            }
         }
 
         private async Task ParseCard(TtsObject card)
@@ -363,11 +619,15 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             if (CardLookup.ContainsKey(nick))
             {
                 CardLookup[nick].Count++;
+                DeckCards.FirstOrDefault(c => c.Card == CardLookup[nick])?.NotifyCountChanged();
+                OnPropertyChanged(nameof(TotalCardCount));
+                OnPropertyChanged(nameof(DeckCountSummary));
                 return;
             }
 
             string face = originalFace;
             FetchOutcome outcome = FetchOutcome.Success; //drives the per-tile status dot
+            string fallbackLang = null; //set when art resolved in a non-preferred language
             if (CardArt.ContainsKey(nick))
             {
                 face = CardArt[nick];
@@ -384,6 +644,8 @@ namespace TTSDeckEditAndCreationTool.ViewModel
                         face = altFace;
                         if (usedLang == PreferredLanguage) _preferredLanguageCount++;
                         else if (usedLang == "en") _defaultLanguageCount++;
+                        if (!string.IsNullOrWhiteSpace(usedLang) && usedLang != PreferredLanguage)
+                            fallbackLang = usedLang.ToUpper();
                         //the fetched url is applied to the model at save time, keyed by the
                         //card's original FaceURL (see SaveDeckToPath), so nothing is mutated here
                     }
@@ -403,12 +665,23 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             temp.Card.OldFaceURL = originalFace;
             temp.Card.Cardname = nick.Split('\n')[0];
             temp.FetchStatus = outcome; //orange (NotFound) / red (Error/RateLimited) dot on the tile
+            temp.LanguageWarning = fallbackLang;
             if (!CardLookup.ContainsKey(nick)) CardLookup.Add(nick, temp.Card);
             DeckCards.Add(temp);
+            OnPropertyChanged(nameof(TotalCardCount));
+            OnPropertyChanged(nameof(UniqueCardCount));
+            OnPropertyChanged(nameof(DeckCountSummary));
         }
 
         public void SaveDeckToPath()
         {
+            // Generation mode: there is no source file to edit — build one from scratch.
+            if (_isGenerated)
+            {
+                SaveGeneratedDeck();
+                return;
+            }
+
             if (_save == null)
             {
                 FeedbackPopupViewModel.Instance.DisplayErrorMessage("No deck loaded to save");
@@ -465,6 +738,53 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             }
 
             FeedbackPopupViewModel.Instance.DisplaySmileMessage("Deck Saved Successfully");
+        }
+
+        // Standard MTG card back used by the TTS community / tts-deckconverter, applied
+        // when the user hasn't set their own card back before generating.
+        private const string DefaultBackURL =
+            "http://cloud-3.steamusercontent.com/ugc/998016607072296897/863E1F6C57E4EE5263552051BC4FFBB30D9E61F4/";
+
+        /// <summary>
+        /// Generation-mode save: build a brand-new TTS Saved Object from the on-screen
+        /// cards (one individual image per card) and write it to a user-chosen path.
+        /// </summary>
+        private void SaveGeneratedDeck()
+        {
+            if (DeckCards == null || DeckCards.Count == 0)
+            {
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage("No cards to save");
+                return;
+            }
+
+            var dialog = new Microsoft.Win32.SaveFileDialog
+            {
+                InitialDirectory = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    "Documents", "My Games", "Tabletop Simulator", "Saves", "Saved Objects"),
+                Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+                FileName = "Generated Deck.json"
+            };
+
+            if (dialog.ShowDialog() != true) return;
+
+            string backUrl = string.IsNullOrWhiteSpace(CardBackURL) ? DefaultBackURL : CardBackURL;
+            string saveName = Path.GetFileNameWithoutExtension(dialog.FileName);
+
+            try
+            {
+                GenSavedObject save = TtsDeckBuilder.Build(
+                    DeckCards.Select(c => c.Card), backUrl, saveName);
+                string json = JsonSerializer.Serialize(save, SaveOptions);
+                File.WriteAllText(dialog.FileName, json);
+            }
+            catch (Exception e)
+            {
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage("Error saving file \n\n " + e.Message);
+                return;
+            }
+
+            FeedbackPopupViewModel.Instance.DisplaySmileMessage("Deck Generated Successfully");
         }
 
         /// <summary>Walks every CustomDeck entry in the deck: pile-level, per-card, and inside card States.</summary>

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/DeckBuilderViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/DeckBuilderViewModel.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Dynamic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Net.Http;
@@ -22,6 +23,17 @@ namespace TTSDeckEditAndCreationTool.ViewModel
         private ObservableCollection<CardBuilderViewModel> _deckCards { get; set; }
 
         private static readonly HttpClient httpClient = new HttpClient();
+
+        // Re-serialize the deck through the typed models when saving.
+        // WriteIndented: readable, diffable output.
+        // UnsafeRelaxedJsonEscaping: keep accents (é) and slashes literal instead of \uXXXX / \/.
+        // WhenWritingNull: a nullable property absent from the source file is not re-emitted as null.
+        private static readonly JsonSerializerOptions SaveOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
 
         static DeckBuilderViewModel()
         {
@@ -84,6 +96,105 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
         public ICommand SaveDeckCommand { get; }
         public ICommand ApplySetStylesCommand { get; }
+        public ICommand RefetchLanguageCommand { get; }
+
+        /// <summary>Series picker; when a set is pinned, fetches pull art from that set. Shared with the import screen.</summary>
+        public SetSelectorViewModel SetSelector { get; } = new SetSelectorViewModel();
+
+        /// <summary>Label for the re-download button, showing which language will be fetched.</summary>
+        public string RefetchLanguageButtonText => $"Re-DL {PreferredLanguage}";
+
+        private bool _isBusy;
+        /// <summary>True while a bulk fetch (Re-DL / Apply) is running. Buttons bind to its inverse.</summary>
+        public bool IsBusy
+        {
+            get => _isBusy;
+            set
+            {
+                _isBusy = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsNotBusy));
+            }
+        }
+        public bool IsNotBusy => !_isBusy;
+
+        private string _fetchStatus;
+        /// <summary>Live progress / result message for bulk fetches, shown next to the buttons.</summary>
+        public string FetchStatus
+        {
+            get => _fetchStatus;
+            set { _fetchStatus = value; OnPropertyChanged(); }
+        }
+
+        private string _busyText;
+        /// <summary>Centered overlay text during a bulk fetch: progress, elapsed time, backoff countdown.</summary>
+        public string BusyText
+        {
+            get => _busyText;
+            set { _busyText = value; OnPropertyChanged(); }
+        }
+
+        // --- Busy/progress overlay state (import & Re-DL) ---
+        private System.Windows.Threading.DispatcherTimer _busyTimer;
+        private DateTime _busyStart;
+        private DateTime? _backoffEndsAt;   // when the current Scryfall backoff wait ends
+        private int _progressDone;
+        private int _progressTotal;
+        private string _busyVerb = "Downloading images";
+
+        // Set by the active VM while busy so the static rate-limit gate can report a backoff.
+        internal static Action<int> BackoffNotifier;
+
+        private void BeginBusy(int total, string verb)
+        {
+            _busyVerb = verb;
+            _progressTotal = total;
+            _progressDone = 0;
+            _busyStart = DateTime.Now;
+            _backoffEndsAt = null;
+            BackoffNotifier = ms => _backoffEndsAt = DateTime.Now.AddMilliseconds(ms);
+            IsBusy = true;
+
+            UpdateBusyText();
+            _busyTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(500)
+            };
+            _busyTimer.Tick += (s, e) => UpdateBusyText();
+            _busyTimer.Start();
+        }
+
+        private void StepProgress()
+        {
+            _progressDone++;
+            UpdateBusyText();
+        }
+
+        private void EndBusy()
+        {
+            _busyTimer?.Stop();
+            _busyTimer = null;
+            BackoffNotifier = null;
+            _backoffEndsAt = null;
+            IsBusy = false;
+        }
+
+        private void UpdateBusyText()
+        {
+            int elapsed = (int)(DateTime.Now - _busyStart).TotalSeconds;
+            string line1 = $"{_busyVerb}…  {_progressDone}/{_progressTotal}";
+            string line3 = $"Elapsed: {elapsed}s";
+
+            if (_backoffEndsAt.HasValue && _backoffEndsAt.Value > DateTime.Now)
+            {
+                int remain = (int)Math.Ceiling((_backoffEndsAt.Value - DateTime.Now).TotalSeconds);
+                BusyText = $"{line1}\nScryfall rate limit reached — resuming in {remain}s…\n{line3}";
+            }
+            else
+            {
+                BusyText = $"{line1}\n{line3}";
+            }
+        }
 
         private string _setAbbreviations;
         public string SetAbbreviations
@@ -93,7 +204,7 @@ namespace TTSDeckEditAndCreationTool.ViewModel
         }
 
         private string _deckPath { get; set; }
-        private string _deckJson { get; set; }
+        private TtsSaveFile _save; //typed, round-trip-safe model of the loaded deck; the single source of truth for saving
         private string _oldCardBackURL { get; set; }
         private bool _isUpdated;
         public bool IsUpdated
@@ -110,6 +221,8 @@ namespace TTSDeckEditAndCreationTool.ViewModel
         {
             SaveDeckCommand = new BuilderSaveDeckCommand(this);
             ApplySetStylesCommand = new ApplySetStylesCommand(this);
+            RefetchLanguageCommand = new RefetchLanguageCommand(this);
+            _ = SetSelector.LoadAsync(); //populate the series picker (cached, fire-and-forget)
         }
 
         public async Task MergeFromPaths(string pathNew, string pathOld)
@@ -137,9 +250,10 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             OnPropertyChanged(nameof(ImportSummary));
 
             //PART 1 : LOAD IN JSON
+            string json;
             try
             {
-                _deckJson = File.ReadAllText(path);
+                json = File.ReadAllText(path);
             }
             catch(Exception e)
             {
@@ -147,10 +261,9 @@ namespace TTSDeckEditAndCreationTool.ViewModel
                 return;
             }
 
-            dynamic rawDeck = null;
             try
             {
-                rawDeck = JsonSerializer.Deserialize<ExpandoObject>(_deckJson);
+                _save = JsonSerializer.Deserialize<TtsSaveFile>(json);
             }
             catch (Exception e)
             {
@@ -158,49 +271,41 @@ namespace TTSDeckEditAndCreationTool.ViewModel
                 return;
             }
 
-            try
+            if (_save?.ObjectStates == null)
             {
-                using JsonDocument doc = JsonDocument.Parse(_deckJson);
-                if (doc.RootElement.TryGetProperty("isUpdated", out JsonElement upd))
-                {
-                    IsUpdated = upd.GetBoolean();
-                }
-                else
-                {
-                    IsUpdated = false;
-                }
-                OnPropertyChanged(nameof(IsUpdated));
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage("Error parsing card info \n\n No ObjectStates found in file");
+                return;
             }
-            catch
-            {
-                IsUpdated = false;
-                OnPropertyChanged(nameof(IsUpdated));
-            }
+
+            IsUpdated = _save.IsUpdated ?? false;
+            OnPropertyChanged(nameof(IsUpdated));
 
             //PART 2 : PARSE OUT CARDS
-            //TODO: Right now this is pretty brute force on navigating the JSON. Ideally I would like to have a replica model of TTS objects so that not only is this cleaner but we can then move into deck creation and management as well.
-
-            var savedObjs = rawDeck.ObjectStates;
+            // Only decks not yet processed actually hit Scryfall; show the overlay just for those.
+            int totalCards = _save.ObjectStates.Sum(o => o.IsDeck ? (o.ContainedObjects?.Count ?? 0) : 1);
+            bool showOverlay = !IsUpdated;
+            if (showOverlay) BeginBusy(totalCards, "Downloading images");
 
             try
             {
-                for (int i = 0; i < savedObjs.GetArrayLength(); i++)
+                // Bulk-load any selected series first so the per-card loop hits the cache.
+                if (showOverlay) await PreloadSelectedSetsAsync();
+
+                foreach (TtsObject obj in _save.ObjectStates)
                 {
-                    JsonElement cObj = savedObjs[i];
-                    JsonElement containedobjects;
-
-                    bool isDeck = cObj.TryGetProperty("ContainedObjects", out containedobjects); //if isDeck then the object in the list is a pile of cards rather than a single
-
-                    if (isDeck)
+                    //a deck is a pile of cards rather than a single card
+                    if (obj.IsDeck)
                     {
-                        foreach (JsonElement jelement in containedobjects.EnumerateArray())
+                        foreach (TtsObject contained in obj.ContainedObjects)
                         {
-                            await ParseJElementCard(jelement);
+                            await ParseCard(contained);
+                            if (showOverlay) StepProgress();
                         }
                     }
                     else
                     {
-                        await ParseJElementCard(cObj);
+                        await ParseCard(obj);
+                        if (showOverlay) StepProgress();
                     }
                 }
             }
@@ -209,185 +314,327 @@ namespace TTSDeckEditAndCreationTool.ViewModel
                 FeedbackPopupViewModel.Instance.DisplayErrorMessage("Error parsing card info \n\n" + e.Message);
                 return;
             }
+            finally
+            {
+                if (showOverlay)
+                {
+                    CardStyleCache.SaveFaceCache(); //persist newly fetched urls for next time
+                    EndBusy();
+                }
+            }
 
             //PART 3 : LOAD ON SCREEN
             OnPropertyChanged(nameof(DeckCards));
             OnPropertyChanged(nameof(CardBackURL));
         }
 
-        private async Task ParseJElementCard(JsonElement jle)
+        private async Task ParseCard(TtsObject card)
         {
-            JsonElement cardstates;
+            await ParseCardFace(card);
 
-            bool hasStates = jle.TryGetProperty("States", out cardstates); //check if the card has states. (relevant for cards with content on the back face)
-
-            await ParseJElementCardFace(jle);
-
-            if (hasStates)
+            //cards with content on the back face expose it through States
+            if (card.States != null)
             {
-                //this means its the BACK of the card
-                foreach (JsonProperty jproperty in cardstates.EnumerateObject())
+                foreach (TtsObject state in card.States.Values)
                 {
-                    await ParseJElementCardFace(jproperty.Value, true);
+                    await ParseCardFace(state, true);
                 }
             }
         }
 
-        private async Task ParseJElementCardFace(JsonElement jle, bool isBack = false)
+        private async Task ParseCardFace(TtsObject card, bool isBack = false)
         {
-            JsonElement nickname, customdeck, faceurl = new JsonElement(), cardid;
+            string nick = card.Nickname ?? "";
+            int cardId = card.CardID ?? 0;
 
-            jle.TryGetProperty("Nickname", out nickname);
-            jle.TryGetProperty("CardID", out cardid);
-            jle.TryGetProperty("CustomDeck", out customdeck);
-
-            foreach (JsonProperty jproperty in customdeck.EnumerateObject())
+            string originalFace = "";
+            if (card.CustomDeck != null)
             {
-                jproperty.Value.TryGetProperty("FaceURL", out faceurl);
-                if (string.IsNullOrWhiteSpace(_oldCardBackURL))
+                foreach (TtsCustomDeckEntry entry in card.CustomDeck.Values)
                 {
-                    JsonElement cardback;
-                    jproperty.Value.TryGetProperty("BackURL", out cardback);
-                    string backValue = cardback.GetString();
-                    if (!string.IsNullOrWhiteSpace(backValue))
+                    originalFace = entry.FaceURL ?? "";
+                    if (string.IsNullOrWhiteSpace(_oldCardBackURL) && !string.IsNullOrWhiteSpace(entry.BackURL))
                     {
-                        CardBackURL = _oldCardBackURL = cardback.GetString();
+                        CardBackURL = _oldCardBackURL = entry.BackURL;
                     }
                 }
             }
-            if (CardLookup.ContainsKey(nickname.GetString()))
+
+            if (CardLookup.ContainsKey(nick))
             {
-                CardLookup[nickname.GetString()].Count++;
+                CardLookup[nick].Count++;
+                return;
+            }
+
+            string face = originalFace;
+            FetchOutcome outcome = FetchOutcome.Success; //drives the per-tile status dot
+            if (CardArt.ContainsKey(nick))
+            {
+                face = CardArt[nick];
             }
             else
             {
-                string nick = nickname.GetString();
-                string originalFace = faceurl.GetString();
-                string face = originalFace;
-                if (CardArt.ContainsKey(nick))
-                {
-                    face = CardArt[nick];
-                }
-                else
-                {
-                    if (!IsUpdated)
-                    {
-                        var result = await FetchPreferredImage(nick.Split("\n")[0], isBack);
-                        string altFace = result?.Url;
-                        string usedLang = result?.Language;
-                        if (!string.IsNullOrWhiteSpace(altFace))
-                        {
-                            face = altFace;
-                            if (usedLang == PreferredLanguage) _preferredLanguageCount++;
-                            else if (usedLang == "en") _defaultLanguageCount++;
-
-                            if (_deckJson != null)
-                            {
-                                if (!string.IsNullOrWhiteSpace(originalFace))
-                                {
-                                    _deckJson = _deckJson.Replace(originalFace, face);
-                                }
-                                else
-                                {
-                                    _deckJson = _deckJson.Replace("\"FaceURL\": \"\"", "\"FaceURL\": \"" + face + "\"");
-                                }
-                            }
-                        }
-                        else
-                        {
-                            _errorCount++;
-                        }
-                        OnPropertyChanged(nameof(ImportSummary));
-                    }
-                    CardArt.Add(nick, face);
-                }
-                CardBuilderViewModel temp = new CardBuilderViewModel(new DeckCard(nick, cardid.GetInt32(), face, isBack));
                 if (!IsUpdated)
                 {
-                    temp.Card.OldFaceURL = face;
+                    var result = await FetchPreferredImage(nick.Split('\n')[0], isBack);
+                    string altFace = result?.Url;
+                    string usedLang = result?.Language;
+                    if (!string.IsNullOrWhiteSpace(altFace))
+                    {
+                        face = altFace;
+                        if (usedLang == PreferredLanguage) _preferredLanguageCount++;
+                        else if (usedLang == "en") _defaultLanguageCount++;
+                        //the fetched url is applied to the model at save time, keyed by the
+                        //card's original FaceURL (see SaveDeckToPath), so nothing is mutated here
+                    }
+                    else
+                    {
+                        _errorCount++;
+                        outcome = result?.Outcome ?? FetchOutcome.Error;
+                    }
+                    OnPropertyChanged(nameof(ImportSummary));
                 }
-                else
-                {
-                    temp.Card.OldFaceURL = originalFace;
-                }
-               
-                temp.Card.Cardname = nick.Split('\n')[0];
-                if (!CardLookup.ContainsKey(nick)) CardLookup.Add(nick, temp.Card);
-                DeckCards.Add(temp);
+                CardArt.Add(nick, face);
             }
+
+            CardBuilderViewModel temp = new CardBuilderViewModel(new DeckCard(nick, cardId, face, isBack));
+            //OldFaceURL is always the url present in the file; the save maps it onto every
+            //matching CustomDeck entry (pile + per-card + states) and onto the new FaceURL
+            temp.Card.OldFaceURL = originalFace;
+            temp.Card.Cardname = nick.Split('\n')[0];
+            temp.FetchStatus = outcome; //orange (NotFound) / red (Error/RateLimited) dot on the tile
+            if (!CardLookup.ContainsKey(nick)) CardLookup.Add(nick, temp.Card);
+            DeckCards.Add(temp);
         }
 
         public void SaveDeckToPath()
         {
-            System.Diagnostics.Debug.WriteLine("====== SAVE START ======");
-            
-            IsUpdated = true;
-            OnPropertyChanged(nameof(IsUpdated));
-
-            if (!string.IsNullOrWhiteSpace(_deckJson))
+            if (_save == null)
             {
-                if (_deckJson.Contains("\"isUpdated\""))
-                {
-                    _deckJson = Regex.Replace(_deckJson, "\"isUpdated\"\\s*:\\s*(true|false)", "\"isUpdated\": true");
-                }
-                else
-                {
-                    int braceIndex = _deckJson.IndexOf('{');
-                    if (braceIndex >= 0)
-                    {
-                        _deckJson = _deckJson.Insert(braceIndex + 1, "\"isUpdated\": true,");
-                    }
-                }
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage("No deck loaded to save");
+                return;
             }
 
+            IsUpdated = true;
+            _save.IsUpdated = true;
 
+            // Map each edited card's original FaceURL to its new one. Cards sharing the
+            // same original url (e.g. duplicate basic lands) are updated together, which
+            // matches the deduped one-tile-per-name model. Empty originals can't be
+            // targeted by url and are left as-is (known limitation, see ParseCardFace).
+            Dictionary<string, string> faceMap = new Dictionary<string, string>();
             foreach (CardBuilderViewModel cardvm in DeckCards)
             {
                 DeckCard card = cardvm.Card;
-
-                System.Diagnostics.Debug.WriteLine($"Card: {card.Cardname}");
-                System.Diagnostics.Debug.WriteLine($"Old URL: {card.OldFaceURL}");
-                System.Diagnostics.Debug.WriteLine($"New URL: {card.FaceURL}");
-                System.Diagnostics.Debug.WriteLine($"Deck JSON contains old? {_deckJson.Contains(card.OldFaceURL)}");
-
-                if (card.FaceURL != card.OldFaceURL)
+                if (card.FaceURL != card.OldFaceURL && !string.IsNullOrWhiteSpace(card.OldFaceURL))
                 {
-                    if (!string.IsNullOrWhiteSpace(card.OldFaceURL))
-                    {
-                        _deckJson = _deckJson.Replace(card.OldFaceURL, card.FaceURL);
-                    }
-                    else
-                    {
-                        _deckJson = _deckJson.Replace("\"FaceURL\": \"\"", "\"FaceURL\": \"" + card.FaceURL + "\"");
-                    }
-                    System.Diagnostics.Debug.WriteLine("-> Replaced URL in JSON");
+                    faceMap[card.OldFaceURL] = card.FaceURL;
                 }
             }
 
-            if (_oldCardBackURL != CardBackURL && !string.IsNullOrWhiteSpace(CardBackURL))
+            bool backChanged = _oldCardBackURL != CardBackURL && !string.IsNullOrWhiteSpace(CardBackURL);
+
+            // Apply every change in a single pass over ALL CustomDeck entries
+            // (pile-level, per-card, and card States) so both copies of a shared url
+            // stay in sync. This is what the old whole-file string.Replace did, but
+            // scoped to the right fields instead of blind text substitution.
+            foreach (TtsCustomDeckEntry entry in EnumerateCustomDeckEntries())
             {
-                System.Diagnostics.Debug.WriteLine($"Old Back URL: {_oldCardBackURL}");
-                System.Diagnostics.Debug.WriteLine($"New Back URL: {CardBackURL}");
-                _deckJson = _deckJson.Replace("BackURL\": \"" + _oldCardBackURL, "BackURL\": \"" + CardBackURL);
+                if (!string.IsNullOrEmpty(entry.FaceURL) && faceMap.TryGetValue(entry.FaceURL, out string newFace))
+                {
+                    entry.FaceURL = newFace;
+                }
+                entry.FaceURL = UpgradeUrlToPng(entry.FaceURL);
+
+                if (backChanged && entry.BackURL == _oldCardBackURL)
+                {
+                    entry.BackURL = CardBackURL;
+                }
+                entry.BackURL = UpgradeUrlToPng(entry.BackURL);
             }
 
-            // Upgrade URLs to png
-            _deckJson = UpgradeImageUrlsToPng(_deckJson);
-
-            // Write the file
-            File.WriteAllText(_deckPath, _deckJson);
-            System.Diagnostics.Debug.WriteLine("====== SAVE COMPLETE ======");
+            try
+            {
+                string json = JsonSerializer.Serialize(_save, SaveOptions);
+                File.WriteAllText(_deckPath, json);
+            }
+            catch (Exception e)
+            {
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage("Error saving file \n\n " + e.Message);
+                return;
+            }
 
             FeedbackPopupViewModel.Instance.DisplaySmileMessage("Deck Saved Successfully");
         }
 
-        private static string UpgradeImageUrlsToPng(string json)
+        /// <summary>Walks every CustomDeck entry in the deck: pile-level, per-card, and inside card States.</summary>
+        private IEnumerable<TtsCustomDeckEntry> EnumerateCustomDeckEntries()
         {
-            if (string.IsNullOrWhiteSpace(json)) return json;
+            if (_save?.ObjectStates == null) yield break;
 
-            json = Regex.Replace(json, "/(small|normal|large)/", "/png/");
+            foreach (TtsObject obj in _save.ObjectStates)
+            {
+                foreach (TtsCustomDeckEntry e in CustomDeckOf(obj)) yield return e;
 
-            return json;
+                if (obj.ContainedObjects != null)
+                {
+                    foreach (TtsObject card in obj.ContainedObjects)
+                    {
+                        foreach (TtsCustomDeckEntry e in CustomDeckOf(card)) yield return e;
+
+                        if (card.States != null)
+                            foreach (TtsObject state in card.States.Values)
+                                foreach (TtsCustomDeckEntry e in CustomDeckOf(state)) yield return e;
+                    }
+                }
+            }
+        }
+
+        private static IEnumerable<TtsCustomDeckEntry> CustomDeckOf(TtsObject obj)
+        {
+            return obj?.CustomDeck != null ? obj.CustomDeck.Values : Enumerable.Empty<TtsCustomDeckEntry>();
+        }
+
+        private static string UpgradeUrlToPng(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url)) return url;
+            url = Regex.Replace(url, "/(small|normal|large)/", "/png/");
+            url = Regex.Replace(url, "\\.jpg", ".png");
+            return url;
+        }
+
+        // Scryfall asks for 50-100ms between requests, but it also uses a token bucket:
+        // an initial burst is tolerated, then a slower sustained rate is enforced with
+        // HTTP 429. We serialize all calls behind this gate (so bursts can't happen),
+        // space them out, and on 429 back off exponentially — honoring the Retry-After
+        // header when present — for several attempts before giving up.
+        private static readonly System.Threading.SemaphoreSlim _scryfallGate = new System.Threading.SemaphoreSlim(1, 1);
+        // /cards/search is a "heavy" endpoint limited to ~2 req/s. Pacing just under that
+        // (~1.8 req/s) means we never trip a 429 — far faster overall than bursting and
+        // eating 30s penalties. The retry/backoff below stays as a safety net.
+        private const int ScryfallDelayMs = 550;       // base spacing between successful calls (~1.8 req/s)
+        private const int ScryfallMaxRetries = 4;      // extra attempts on 429
+
+        private static async Task<HttpResponseMessage> GetWithRateLimitAsync(string url)
+        {
+            await _scryfallGate.WaitAsync();
+            try
+            {
+                int backoffMs = 500;
+                HttpResponseMessage res = await httpClient.GetAsync(url);
+
+                for (int attempt = 0; attempt < ScryfallMaxRetries && (int)res.StatusCode == 429; attempt++)
+                {
+                    // Respect Scryfall's Retry-After (seconds) if it tells us how long to wait.
+                    int waitMs = backoffMs;
+                    if (res.Headers.RetryAfter?.Delta is TimeSpan ra && ra.TotalMilliseconds > 0)
+                    {
+                        waitMs = (int)ra.TotalMilliseconds;
+                    }
+                    res.Dispose();
+                    BackoffNotifier?.Invoke(waitMs); // let the overlay show a countdown
+                    await Task.Delay(waitMs);
+                    backoffMs *= 2; // 500, 1000, 2000, 4000...
+                    res = await httpClient.GetAsync(url);
+                }
+                return res;
+            }
+            finally
+            {
+                // Hold the spacing inside the lock so the *next* caller waits too.
+                await Task.Delay(ScryfallDelayMs);
+                _scryfallGate.Release();
+            }
+        }
+
+        /// <summary>
+        /// Bulk-loads every selected series into the face cache up front. A set search
+        /// (set:CODE) returns ~175 cards per page, so a whole series costs a handful of
+        /// requests instead of one-per-card. After this runs, FetchPreferredImage resolves
+        /// most cards straight from the cache (no network), turning a ~430s import into ~15s.
+        /// Cards in none of the selected sets simply fall through to the normal per-card path.
+        /// </summary>
+        private async Task PreloadSelectedSetsAsync()
+        {
+            List<string> setCodes = SetSelector?.SelectedSetCodes;
+            if (setCodes == null || setCodes.Count == 0) return;
+
+            List<string> languages = new List<string> { PreferredLanguage };
+            if (PreferredLanguage != "en") languages.Add("en");
+
+            foreach (string setCode in setCodes)
+            {
+                foreach (string lang in languages)
+                {
+                    string url = $"https://api.scryfall.com/cards/search?q=set:{setCode}+lang:{lang}&unique=prints";
+                    while (!string.IsNullOrEmpty(url))
+                    {
+                        if (IsBusy) FetchStatus = $"Preloading set {setCode.ToUpper()} [{lang}]…";
+                        url = await PreloadPageAsync(url, lang, setCode);
+                    }
+                }
+            }
+        }
+
+        /// <summary>Fetches one search page, caches each card's face url(s), returns the next page url or null.</summary>
+        private async Task<string> PreloadPageAsync(string url, string lang, string setCode)
+        {
+            try
+            {
+                using HttpResponseMessage res = await GetWithRateLimitAsync(url);
+                if (!res.IsSuccessStatusCode) return null;
+
+                string data = await res.Content.ReadAsStringAsync();
+                JsonElement root = JsonSerializer.Deserialize<JsonElement>(data);
+                if (!root.TryGetProperty("data", out JsonElement cards) || cards.ValueKind != JsonValueKind.Array)
+                    return null;
+
+                foreach (JsonElement card in cards.EnumerateArray())
+                {
+                    if (!card.TryGetProperty("name", out JsonElement nameEl)) continue;
+                    // Deck nicknames use only the front-face name, so key the cache on that.
+                    string keyName = (nameEl.GetString() ?? "").Split(new[] { " // " }, StringSplitOptions.None)[0];
+                    if (string.IsNullOrWhiteSpace(keyName)) continue;
+
+                    if (card.TryGetProperty("image_uris", out JsonElement imgs))
+                    {
+                        string u = PickNormal(imgs);
+                        if (u != null) CardStyleCache.StoreCachedFace(keyName, lang, false, u, setCode);
+                    }
+                    else if (card.TryGetProperty("card_faces", out JsonElement faces) && faces.ValueKind == JsonValueKind.Array)
+                    {
+                        var faceList = faces.EnumerateArray().ToList();
+                        if (faceList.Count > 0 && faceList[0].TryGetProperty("image_uris", out JsonElement f0))
+                        {
+                            string u = PickNormal(f0);
+                            if (u != null) CardStyleCache.StoreCachedFace(keyName, lang, false, u, setCode);
+                        }
+                        if (faceList.Count > 1 && faceList[1].TryGetProperty("image_uris", out JsonElement f1))
+                        {
+                            string u = PickNormal(f1);
+                            if (u != null) CardStyleCache.StoreCachedFace(keyName, lang, true, u, setCode);
+                        }
+                    }
+                }
+
+                if (root.TryGetProperty("has_more", out JsonElement more) && more.ValueKind == JsonValueKind.True
+                    && root.TryGetProperty("next_page", out JsonElement next))
+                {
+                    return next.GetString();
+                }
+            }
+            catch
+            {
+                // best effort: a failed preload just means those cards hit the per-card path
+            }
+            return null;
+        }
+
+        private static string PickNormal(JsonElement imageUris)
+        {
+            if (imageUris.TryGetProperty("normal", out JsonElement n)) return n.GetString();
+            if (imageUris.TryGetProperty("small", out JsonElement s)) return s.GetString();
+            return null;
         }
 
         private async Task<FetchedImageResult> FetchPreferredImage(string cardName, bool isBack)
@@ -399,74 +646,217 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             }
             if (PreferredLanguage != "en") languages.Add("en");
 
-            foreach (string lang in languages)
+            // Series to try, in priority order. Empty selection -> a single null = "any set".
+            List<string> setCodes = SetSelector?.SelectedSetCodes;
+            if (setCodes == null || setCodes.Count == 0) setCodes = new List<string> { null };
+
+            // Track why we failed so the caller can tell "rate-limited" from "no art in
+            // this language/set". RateLimited wins over Error wins over NotFound for reporting.
+            bool sawRateLimit = false;
+            bool sawError = false;
+
+            // Outer loop = chosen series (priority order); inner = languages.
+            // First printing found in any chosen set, preferred language first, wins.
+            foreach (string setCode in setCodes)
             {
-                try
+                foreach (string lang in languages)
                 {
-                    string urlName = cardName.Replace(' ', '_');
-                    string baseUrl = "https://api.scryfall.com/cards/search?q=!" + urlName + " lang:" + lang + "&unique=prints";
-
-                    HttpResponseMessage res = await httpClient.GetAsync(baseUrl);
-                    if (res.IsSuccessStatusCode)
+                    // Cache hit: skip the network and the rate-limit gate entirely.
+                    string cached = CardStyleCache.GetCachedFace(cardName, lang, isBack, setCode);
+                    if (!string.IsNullOrWhiteSpace(cached))
                     {
-                        string data = await res.Content.ReadAsStringAsync();
-                        JsonElement root = JsonSerializer.Deserialize<JsonElement>(data);
-                        if (root.TryGetProperty("data", out JsonElement cardInfos))
+                        return new FetchedImageResult { Url = cached, Language = lang, Outcome = FetchOutcome.Success };
+                    }
+
+                    try
+                    {
+                        string urlName = cardName.Replace(' ', '_');
+                        string setFilter = string.IsNullOrWhiteSpace(setCode) ? "" : " set:" + setCode;
+                        string baseUrl = "https://api.scryfall.com/cards/search?q=!" + urlName + " lang:" + lang + setFilter + "&unique=prints";
+
+                        using HttpResponseMessage res = await GetWithRateLimitAsync(baseUrl);
+                        if ((int)res.StatusCode == 429)
                         {
-                            foreach (JsonElement cardInfo in cardInfos.EnumerateArray())
+                            sawRateLimit = true;
+                            continue;
+                        }
+                        if (res.IsSuccessStatusCode)
+                        {
+                            string data = await res.Content.ReadAsStringAsync();
+                            JsonElement root = JsonSerializer.Deserialize<JsonElement>(data);
+                            if (root.TryGetProperty("data", out JsonElement cardInfos) && cardInfos.ValueKind == JsonValueKind.Array)
                             {
-                                JsonElement cardImages, cardImage, cardFaces;
-
-                                if (cardInfo.TryGetProperty("image_uris", out cardImages))
+                                foreach (JsonElement cardInfo in cardInfos.EnumerateArray())
                                 {
-                                    if (!cardImages.TryGetProperty("normal", out cardImage))
+                                    JsonElement cardImages, cardImage, cardFaces;
+
+                                    if (cardInfo.TryGetProperty("image_uris", out cardImages))
                                     {
-                                        cardImages.TryGetProperty("small", out cardImage);
+                                        if (!cardImages.TryGetProperty("normal", out cardImage))
+                                        {
+                                            cardImages.TryGetProperty("small", out cardImage);
+                                        }
                                     }
-                                }
-                                else if (cardInfo.TryGetProperty("card_faces", out cardFaces))
-                                {
-                                    cardFaces[isBack ? 1 : 0].TryGetProperty("image_uris", out cardImages);
-                                    cardImages.TryGetProperty("normal", out cardImage);
-                                }
-                                else
-                                {
-                                    continue;
-                                }
+                                    else if (cardInfo.TryGetProperty("card_faces", out cardFaces))
+                                    {
+                                        cardFaces[isBack ? 1 : 0].TryGetProperty("image_uris", out cardImages);
+                                        cardImages.TryGetProperty("normal", out cardImage);
+                                    }
+                                    else
+                                    {
+                                        continue;
+                                    }
 
-                                return new FetchedImageResult
-                                {
-                                    Url = cardImage.GetString(),
-                                    Language = lang
-                                };
+                                    string foundUrl = cardImage.GetString();
+                                    CardStyleCache.StoreCachedFace(cardName, lang, isBack, foundUrl, setCode);
+                                    return new FetchedImageResult
+                                    {
+                                        Url = foundUrl,
+                                        Language = lang,
+                                        Outcome = FetchOutcome.Success
+                                    };
+                                }
                             }
+                            // 200 OK but no usable print in this language/set: try the next
+                            // language, then the next chosen set.
+                        }
+                        else
+                        {
+                            sawError = true;
                         }
                     }
-                }
-                catch
-                {
+                    catch
+                    {
+                        sawError = true;
+                    }
                 }
             }
 
-            return null;
+            FetchOutcome outcome = sawRateLimit ? FetchOutcome.RateLimited
+                                 : sawError ? FetchOutcome.Error
+                                 : FetchOutcome.NotFound;
+            return new FetchedImageResult { Outcome = outcome };
+        }
+
+        /// <summary>
+        /// Re-fetches every card's art in the current <see cref="PreferredLanguage"/> and updates
+        /// the gallery in place. This is an explicit user action (the "Re-download" button), so it
+        /// runs regardless of <see cref="IsUpdated"/> — unlike the import, which skips fetching for
+        /// decks already marked processed. The new urls are committed to the file on the next Save.
+        /// </summary>
+        public async Task RefreshImagesInPreferredLanguage()
+        {
+            if (DeckCards == null || IsBusy) return;
+
+            _preferredLanguageCount = 0;
+            _defaultLanguageCount = 0;
+            _errorCount = 0;
+            OnPropertyChanged(nameof(ImportSummary));
+
+            int notFound = 0;
+            int rateLimited = 0;
+            var issues = new List<string>();
+
+            BeginBusy(DeckCards.Count, $"Re-downloading {PreferredLanguage}");
+            try
+            {
+                // Bulk-load any selected series first so the per-card loop hits the cache.
+                await PreloadSelectedSetsAsync();
+
+                foreach (CardBuilderViewModel cardvm in DeckCards)
+                {
+                    StepProgress();
+
+                    var result = await FetchPreferredImage(cardvm.Card.Cardname, cardvm.Card.BackFace);
+                    if (result != null && !string.IsNullOrWhiteSpace(result.Url))
+                    {
+                        cardvm.UpdateCardFaceURL(result.Url);
+                        cardvm.FetchStatus = FetchOutcome.Success;
+                        if (result.Language == PreferredLanguage) _preferredLanguageCount++;
+                        else if (result.Language == "en") _defaultLanguageCount++;
+                    }
+                    else
+                    {
+                        _errorCount++;
+                        FetchOutcome outcome = result?.Outcome ?? FetchOutcome.Error;
+                        cardvm.FetchStatus = outcome;
+                        if (outcome == FetchOutcome.NotFound) notFound++;
+                        else if (outcome == FetchOutcome.RateLimited) rateLimited++;
+                        issues.Add($"{cardvm.Card.Cardname}\t{outcome}");
+                    }
+                    OnPropertyChanged(nameof(ImportSummary));
+                }
+
+                string summary = $"Done: {_preferredLanguageCount} {PreferredLanguage}, {_defaultLanguageCount} en, " +
+                                 $"{notFound} not found, {rateLimited} rate-limited";
+                if (issues.Count > 0)
+                {
+                    string logPath = LogFetchIssues(issues, rateLimited, notFound);
+                    summary += $" — see log: {logPath}";
+                }
+                FetchStatus = summary;
+            }
+            finally
+            {
+                CardStyleCache.SaveFaceCache(); //persist newly fetched urls for next time
+                EndBusy();
+            }
+        }
+
+        /// <summary>
+        /// Appends the failed cards (with their cause) to a log file under %ProgramData%\DEACT
+        /// so the user can tell rate-limiting (transient, retry later) from genuinely missing
+        /// art in the chosen language. Returns the log path for display.
+        /// </summary>
+        private string LogFetchIssues(List<string> issues, int rateLimited, int notFound)
+        {
+            try
+            {
+                string folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "DEACT");
+                Directory.CreateDirectory(folder);
+                string logPath = Path.Combine(folder, "DEACT_fetch_errors.log");
+
+                var sb = new StringBuilder();
+                sb.AppendLine($"==== Re-download [{PreferredLanguage}] @ {DateTime.Now:yyyy-MM-dd HH:mm:ss} ====");
+                sb.AppendLine($"{rateLimited} rate-limited (transient — retry later), {notFound} not found in '{PreferredLanguage}'.");
+                foreach (string line in issues) sb.AppendLine(line);
+                sb.AppendLine();
+
+                File.AppendAllText(logPath, sb.ToString());
+                return logPath;
+            }
+            catch
+            {
+                return "(could not write log)";
+            }
         }
 
         public async Task ApplySetStyles()
         {
-            if (string.IsNullOrWhiteSpace(SetAbbreviations) || DeckCards == null) return;
+            if (string.IsNullOrWhiteSpace(SetAbbreviations) || DeckCards == null || IsBusy) return;
 
-            List<string> sets = SetAbbreviations.Split(',').Select(s => s.Trim()).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
-            foreach (var cardvm in DeckCards)
+            BeginBusy(DeckCards.Count, "Applying set styles");
+            try
             {
-                foreach (string set in sets)
+                List<string> sets = SetAbbreviations.Split(',').Select(s => s.Trim()).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+                foreach (var cardvm in DeckCards)
                 {
-                    var result = await FetchImageForSet(cardvm.Card.Cardname, set, cardvm.Card.BackFace);
-                    if (result != null && !string.IsNullOrWhiteSpace(result.Url))
+                    StepProgress();
+                    foreach (string set in sets)
                     {
-                        cardvm.UpdateCardFaceURL(result.Url);
-                        break;
+                        var result = await FetchImageForSet(cardvm.Card.Cardname, set, cardvm.Card.BackFace);
+                        if (result != null && !string.IsNullOrWhiteSpace(result.Url))
+                        {
+                            cardvm.UpdateCardFaceURL(result.Url);
+                            break;
+                        }
                     }
                 }
+                FetchStatus = "Set styles applied.";
+            }
+            finally
+            {
+                EndBusy();
             }
         }
 
@@ -476,12 +866,12 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             {
                 string urlName = cardName.Replace(' ', '_');
                 string baseUrl = $"https://api.scryfall.com/cards/search?q=!{urlName}+set:{setAbbrev}+lang:{PreferredLanguage}&unique=prints";
-                HttpResponseMessage res = await httpClient.GetAsync(baseUrl);
+                HttpResponseMessage res = await GetWithRateLimitAsync(baseUrl);
                 if (res.IsSuccessStatusCode)
                 {
                     string data = await res.Content.ReadAsStringAsync();
                     JsonElement root = JsonSerializer.Deserialize<JsonElement>(data);
-                    if (root.TryGetProperty("data", out JsonElement cardInfos))
+                    if (root.TryGetProperty("data", out JsonElement cardInfos) && cardInfos.ValueKind == JsonValueKind.Array)
                     {
                         foreach (JsonElement cardInfo in cardInfos.EnumerateArray())
                         {
@@ -522,8 +912,17 @@ namespace TTSDeckEditAndCreationTool.ViewModel
     }
 }
 
+public enum FetchOutcome
+{
+    Success,        // image found in a requested language
+    NotFound,       // server answered OK but no print exists in the requested language(s)
+    RateLimited,    // server returned HTTP 429 even after retries
+    Error           // network/parse failure
+}
+
 public class FetchedImageResult
 {
     public string Url { get; set; }
     public string Language { get; set; }
+    public FetchOutcome Outcome { get; set; } = FetchOutcome.Success;
 }

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/DecklistImportViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/DecklistImportViewModel.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using TTSDeckEditAndCreationTool.Commands;
+using TTSDeckEditAndCreationTool.Model;
+using TTSDeckEditAndCreationTool.Store;
+
+namespace TTSDeckEditAndCreationTool.ViewModel
+{
+    /// <summary>
+    /// Generation entry screen: the user pastes a Magic decklist (optionally with a
+    /// preferred language and pinned series), and the app resolves each card against
+    /// Scryfall and builds a TTS Saved Object from scratch. Mirrors the structure of
+    /// <see cref="ImportDeckViewModel"/> but takes pasted text instead of a TTS file.
+    /// </summary>
+    public class DecklistImportViewModel : ViewModelBase
+    {
+        private readonly NavigationStore _navigationStore;
+
+        public DeckBuilderViewModel DeckBuilderInstance { get; }
+
+        private string _decklistText = "";
+        public string DecklistText
+        {
+            get => _decklistText;
+            set { _decklistText = value; OnPropertyChanged(); }
+        }
+
+        /// <summary>Series picker, shared with the gallery (pinned sets steer art resolution).</summary>
+        public SetSelectorViewModel SetSelector => DeckBuilderInstance.SetSelector;
+
+        // Same language set as the import screen.
+        private readonly Dictionary<string, string> _languageMap = new Dictionary<string, string>
+        {
+            { "English", "en" },
+            { "French", "fr" },
+            { "German", "de" },
+            { "Italian", "it" },
+            { "Spanish", "es" },
+            { "Portuguese", "pt" },
+            { "Japanese", "ja" },
+            { "Korean", "ko" },
+            { "Russian", "ru" },
+            { "Simplified Chinese", "zhs" },
+            { "Traditional Chinese", "zht" },
+        };
+
+        public IEnumerable<string> Languages => _languageMap.Keys;
+
+        private string _selectedLanguage = "French";
+        public string SelectedLanguage
+        {
+            get => _selectedLanguage;
+            set { _selectedLanguage = value; OnPropertyChanged(); }
+        }
+
+        public ICommand GenerateCommand { get; }
+
+        public DecklistImportViewModel(NavigationStore navigationStore)
+        {
+            _navigationStore = navigationStore;
+            DeckBuilderInstance = new DeckBuilderViewModel();
+            GenerateCommand = new GenerateDeckFromListCommand(this);
+        }
+
+        public async Task GenerateDeckAndNavigate()
+        {
+            List<ParsedDeckLine> lines = DecklistParser.Parse(DecklistText);
+            if (lines.Count == 0)
+            {
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage(
+                    "No cards found. Paste a decklist like:\n\n1 Sol Ring (C21) 263\n10 Forest");
+                return;
+            }
+
+            DeckBuilderInstance.PreferredLanguage = _languageMap[SelectedLanguage];
+
+            _navigationStore.CurrentViewModel = DeckBuilderInstance;
+            await DeckBuilderInstance.LoadFromDecklist(lines);
+        }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/HomeViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/HomeViewModel.cs
@@ -13,11 +13,13 @@ namespace TTSDeckEditAndCreationTool.ViewModel
     {
         public ICommand SwitchToQBGCommand { get; }
         public ICommand SwitchToDeckImportCommand { get; }
+        public ICommand SwitchToDeckGenerateCommand { get; }
         public ICommand SwitchToDeckMergeCommand { get; }
         public HomeViewModel(NavigationStore navigationStore)
         {
             SwitchToQBGCommand = new NavigateCommand<QuickBGViewModel>(navigationStore, () => new QuickBGViewModel(navigationStore));
             SwitchToDeckImportCommand = new NavigateCommand<ImportDeckViewModel>(navigationStore, () => new ImportDeckViewModel(navigationStore));
+            SwitchToDeckGenerateCommand = new NavigateCommand<DecklistImportViewModel>(navigationStore, () => new DecklistImportViewModel(navigationStore));
             SwitchToDeckMergeCommand = new NavigateCommand<MergeDeckViewModel>(navigationStore, () => new MergeDeckViewModel(navigationStore));
         }
     }

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/ImportDeckViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/ImportDeckViewModel.cs
@@ -22,11 +22,15 @@ namespace TTSDeckEditAndCreationTool.ViewModel
     /// </summary>
     class ImportDeckViewModel : ViewModelBase
     {
+        private const string PathPlaceholder = "File Path...";
+
         private string _deckFilePath;
         public string DeckFilePath
         {
-            get { return string.IsNullOrWhiteSpace(_deckFilePath) ? "File Path..." : _deckFilePath; }
-            set { _deckFilePath = value; }
+            // Placeholder is only a display hint; never let it become the real value
+            // (the editable Sets combo can trigger a write-back of the shown text).
+            get { return string.IsNullOrWhiteSpace(_deckFilePath) ? PathPlaceholder : _deckFilePath; }
+            set { _deckFilePath = (value == PathPlaceholder) ? null : value; }
         }
 
         private DeckInfoStore deckInfo { get; set; }
@@ -52,6 +56,9 @@ namespace TTSDeckEditAndCreationTool.ViewModel
         {
             get { return LanguageConverter.Keys; }
         }
+
+        /// <summary>Series picker, shared with the deck builder so a set chosen here is still pinned in the gallery.</summary>
+        public SetSelectorViewModel SetSelector => _deckBuilderViewModel.SetSelector;
 
         private string _selectedLanguage;
         public string SelectedLanguage
@@ -111,7 +118,14 @@ namespace TTSDeckEditAndCreationTool.ViewModel
         /// </summary>
         public async Task ConvertPathToDeckAndNavigate()
         {
-            deckInfo.DeckPath = DeckFilePath;
+            // Guard against the placeholder / a non-existent path being used as the file.
+            if (string.IsNullOrWhiteSpace(_deckFilePath) || !File.Exists(_deckFilePath))
+            {
+                FeedbackPopupViewModel.Instance.DisplayErrorMessage("Please select a deck file first (use Browse).");
+                return;
+            }
+
+            deckInfo.DeckPath = _deckFilePath;
             if(LanguageConverter.ContainsKey(SelectedLanguage))
             {
                 _deckBuilderViewModel.PreferredLanguage = LanguageConverter[SelectedLanguage];
@@ -125,7 +139,7 @@ namespace TTSDeckEditAndCreationTool.ViewModel
 
             if (_deckBuilderViewModel != null)
             {
-                await _deckBuilderViewModel.LoadFromPath(DeckFilePath);
+                await _deckBuilderViewModel.LoadFromPath(_deckFilePath);
             }
         }
     }

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/QuickBGViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/QuickBGViewModel.cs
@@ -110,7 +110,10 @@ namespace TTSDeckEditAndCreationTool.ViewModel
                     }
                 }
 
-                string replacementBase = jsonString.Substring(startIndex, endIndex - startIndex - 1);
+                // grab the existing card back URL from the json
+                // endIndex currently points at the closing quote of the URL so
+                // subtracting 1 was causing the final character to be dropped
+                string replacementBase = jsonString.Substring(startIndex, endIndex - startIndex);
 
                 OutputTextBlock += "replacement target set to: " + replacementBase + "\n";
                 OutputTextBlock += "replacement string set to: " + BackImageURL + "\n";

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/SetSelectorViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/SetSelectorViewModel.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using TTSDeckEditAndCreationTool.Commands;
+using TTSDeckEditAndCreationTool.Model;
+using TTSDeckEditAndCreationTool.Store;
+
+namespace TTSDeckEditAndCreationTool.ViewModel
+{
+    /// <summary>
+    /// Backs the series picker. Typing in the editable combo filters the full set list
+    /// (contains-match on name or code); picking an entry ADDS it to <see cref="SelectedSets"/>
+    /// rather than replacing, so several series can be chosen (e.g. all the Final Fantasy sets).
+    /// Selected series show as removable chips.
+    ///
+    /// At fetch time the chosen sets are tried in order: for each card the first set that has
+    /// a printing (in the requested language) wins. Cards in none of the sets keep their art
+    /// and get an orange dot. Empty selection = no constraint (any set).
+    ///
+    /// Shared between the import screen and the gallery (same instance on the deck VM), so a
+    /// selection made before import is still active for a later Re-DL.
+    /// </summary>
+    public class SetSelectorViewModel : ViewModelBase
+    {
+        private const int MaxResults = 80;
+
+        private List<MagicSet> _all = new List<MagicSet>();
+
+        /// <summary>Series chosen by the user, in priority order.</summary>
+        public ObservableCollection<MagicSet> SelectedSets { get; } = new ObservableCollection<MagicSet>();
+
+        public ICommand RemoveSetCommand { get; }
+
+        public SetSelectorViewModel()
+        {
+            RemoveSetCommand = new RelayCommand(p =>
+            {
+                if (p is MagicSet s && SelectedSets.Contains(s))
+                {
+                    SelectedSets.Remove(s);
+                    OnPropertyChanged(nameof(HasSelection));
+                }
+            });
+        }
+
+        private string _searchText = "";
+        /// <summary>Free text bound to the editable combo; drives <see cref="FilteredSets"/>.</summary>
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                _searchText = value ?? "";
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(FilteredSets));
+            }
+        }
+
+        private MagicSet _comboSelection;
+        /// <summary>
+        /// Transient binding for the combo's SelectedItem. Picking an item adds it to
+        /// <see cref="SelectedSets"/> then resets, so the combo always reads empty and is
+        /// ready for the next search.
+        /// </summary>
+        public MagicSet ComboSelection
+        {
+            get => _comboSelection;
+            set
+            {
+                _comboSelection = value;
+                if (value != null)
+                {
+                    if (!SelectedSets.Any(s => s.Code == value.Code))
+                    {
+                        SelectedSets.Add(value);
+                        OnPropertyChanged(nameof(HasSelection));
+                    }
+                    // reset combo + search for the next pick
+                    _comboSelection = null;
+                    OnPropertyChanged(nameof(ComboSelection));
+                    SearchText = "";
+                }
+            }
+        }
+
+        public bool HasSelection => SelectedSets.Count > 0;
+
+        /// <summary>Set codes to fetch from (lower-case), in priority order. Empty = no constraint.</summary>
+        public List<string> SelectedSetCodes =>
+            SelectedSets.Where(s => !string.IsNullOrWhiteSpace(s.Code))
+                        .Select(s => s.Code.ToLower())
+                        .ToList();
+
+        public IEnumerable<MagicSet> FilteredSets
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_searchText))
+                    return _all.Take(MaxResults);
+
+                string q = _searchText.Trim().ToLower();
+                return _all
+                    .Where(s => (s.Name != null && s.Name.ToLower().Contains(q))
+                             || (s.Code != null && s.Code.ToLower().Contains(q)))
+                    .Take(MaxResults);
+            }
+        }
+
+        /// <summary>Loads the set catalog (cached) and refreshes the list.</summary>
+        public async Task LoadAsync()
+        {
+            await SetCatalog.EnsureLoadedAsync();
+            _all = SetCatalog.Sets.ToList();
+            OnPropertyChanged(nameof(FilteredSets));
+        }
+    }
+}

--- a/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/StyleSelectionViewModel.cs
+++ b/TTSDeckEditAndCreationTool/TTSDeckEditAndCreationTool/ViewModel/StyleSelectionViewModel.cs
@@ -206,20 +206,44 @@ namespace TTSDeckEditAndCreationTool.ViewModel
             {
                 using (HttpClient client = new HttpClient())
                 {
-                    client.DefaultRequestHeaders.Add("User-Agent", "MyApp/1.0 (contact@example.com)");
+                    client.DefaultRequestHeaders.Add("User-Agent", "DEACT/1.0 (contact@example.com)");
                     client.DefaultRequestHeaders.Add("Accept", "application/json");
-                    using (HttpResponseMessage res = await client.GetAsync(baseUrl))
+
+                    HttpResponseMessage res = await client.GetAsync(baseUrl);
+                    // Scryfall rate-limits bursts with HTTP 429; back off exponentially
+                    // (honoring Retry-After) for a few attempts before giving up.
+                    int backoffMs = 500;
+                    for (int attempt = 0; attempt < 4 && (int)res.StatusCode == 429; attempt++)
+                    {
+                        int waitMs = res.Headers.RetryAfter?.Delta is TimeSpan ra && ra.TotalMilliseconds > 0
+                            ? (int)ra.TotalMilliseconds
+                            : backoffMs;
+                        res.Dispose();
+                        await Task.Delay(waitMs);
+                        backoffMs *= 2;
+                        res = await client.GetAsync(baseUrl);
+                    }
+
+                    using (res)
                     {
                         using (HttpContent content = res.Content)
                         {
                             var data = await content.ReadAsStringAsync();
-                            if (content != null)
+                            if (res.IsSuccessStatusCode)
                             {
                                 JsonElement testObject, cardInfos;
                                 testObject = JsonSerializer.Deserialize<JsonElement>(data);
                                 testObject.TryGetProperty("data", out cardInfos);
                                 testObject.TryGetProperty("has_more", out hasNext);
                                 testObject.TryGetProperty("next_page", out nextUrl);
+
+                                // On a rate-limited / error response there is no "data" array;
+                                // guard against EnumerateArray throwing on a non-array element.
+                                if (cardInfos.ValueKind != JsonValueKind.Array)
+                                {
+                                    FeedbackPopupViewModel.Instance.DisplayErrorMessage("Scryfall returned no card data (possibly rate-limited). Please retry.");
+                                    return;
+                                }
 
                                 foreach (JsonElement cardInfo in cardInfos.EnumerateArray())
                                 {


### PR DESCRIPTION
  ## Summary
  Adds a decklist → TTS Saved Object generator. The TTS Scryfall importer was
  disabled, so the tool pivots from editing an imported file to generating the
  JSON from scratch (chosen FR art placed per card at generation time). The
  legacy import/edit path is kept fully intact alongside the new flow.

  ## What's included
  - Decklist parser: `qty Name (SET) number` lines, foil/tag stripping, headers skipped.
  - TtsDeckBuilder + write-only Gen* DTOs: one DeckCustom pile, one CustomDeck
    entry per unique image, DeckIDs/ContainedObjects per copy, double-faced cards
    via States["2"]. Reads image_uris/card_faces, never reconstructs URLs.
  - New decklist screen (paste + language + series picker), reusing the existing
    gallery and art-selection flow. Save branches to generation.
  - Perf: both faces from one Scryfall response; preloaded sets skip the network
    (was ~690s for 89 cards).
  - Gallery indicators: double-faced badge, non-preferred-language badge, total/unique counter.

  ## Testing
  - Builds clean (0 C# errors). Generation test harness: 21/21 pass.
  - Manually exercised: generate from pasted decklist, art selection, DFC handling, save.